### PR TITLE
chore: Removing debug build from upload action.

### DIFF
--- a/.github/workflows/upload-package.yml
+++ b/.github/workflows/upload-package.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         os: [windows, linux]
-        build_type: [Release, Debug]
 
     steps:
     - uses: actions/checkout@v4
@@ -28,7 +27,7 @@ jobs:
       run: |
         conan remote add artifactory https://artifactory.matthewcotton.net/artifactory/api/conan/conan-local
         conan remote login artifactory ci -p ${{ secrets.ARTIFACTS_TOKEN }}
-        conan create . --profile conan/profiles/${{ matrix.os }}_profile --build=missing -s build_type=${{ matrix.build_type }}
+        conan create . --profile conan/profiles/${{ matrix.os }}_profile --build=missing -s build_type=Release
         conan upload moth_ui_editor --confirm --remote artifactory
 
   tag-package:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified the build process by removing the Debug configuration; all builds now use the Release configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->