### PR TITLE
Add autosave and crash recovery features to moth_editor

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,15 +2,6 @@ name: Build and Test
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ master ]
-    paths:
-      - 'src/**'
-      - 'CMakeLists.txt'
-      - 'conanfile.py'
-      - 'version.txt'
-      - '.conan/**'
-      - '.github/workflows/**'
   pull_request:
     branches: [ master ]
     paths:

--- a/conanfile.py
+++ b/conanfile.py
@@ -18,7 +18,7 @@ class MothUIEditor(ConanFile):
         self.version = load(self, "version.txt").strip()
 
     def requirements(self):
-        self.requires("moth_graphics/0.8.0")
+        self.requires("moth_graphics/0.9.0")
         self.requires("moth_packer/0.2.1")
 
     def system_requirements(self):

--- a/example/conanfile.py
+++ b/example/conanfile.py
@@ -8,7 +8,7 @@ class MothUIExample(ConanFile):
     generators = "CMakeToolchain", "CMakeDeps", "MSBuildToolchain", "MSBuildDeps"
 
     def requirements(self):
-        self.requires("moth_graphics/0.8.0")
+        self.requires("moth_graphics/0.9.0")
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.27.0]")

--- a/src/editor/editor_config.h
+++ b/src/editor/editor_config.h
@@ -78,6 +78,6 @@ inline void from_json(nlohmann::json j, EditorConfig& config) {
     config.SnapToAngle = j.value("SnapToAngle", config.SnapToAngle);
     config.SnapAngle = j.value("SnapAngle", config.SnapAngle);
     config.AutoSaveEnabled = j.value("AutoSaveEnabled", config.AutoSaveEnabled);
-    config.AutoSaveIntervalMinutes = j.value("AutoSaveIntervalMinutes", config.AutoSaveIntervalMinutes);
-    config.AutoSaveMaxVersions = j.value("AutoSaveMaxVersions", config.AutoSaveMaxVersions);
+    config.AutoSaveIntervalMinutes = std::clamp(j.value("AutoSaveIntervalMinutes", config.AutoSaveIntervalMinutes), 1, 1440);
+    config.AutoSaveMaxVersions = std::clamp(j.value("AutoSaveMaxVersions", config.AutoSaveMaxVersions), 1, 100);
 }

--- a/src/editor/editor_config.h
+++ b/src/editor/editor_config.h
@@ -26,6 +26,10 @@ struct EditorConfig {
     bool SnapToGrid = false;
     bool SnapToAngle = false;
     float SnapAngle = 15.0f;
+
+    bool AutoSaveEnabled = false;
+    int AutoSaveIntervalMinutes = 5;
+    int AutoSaveMaxVersions = 5;
 };
 
 inline void to_json(nlohmann::json& j, EditorConfig const& config) {
@@ -48,6 +52,9 @@ inline void to_json(nlohmann::json& j, EditorConfig const& config) {
     j["SnapToGrid"] = config.SnapToGrid;
     j["SnapToAngle"] = config.SnapToAngle;
     j["SnapAngle"] = config.SnapAngle;
+    j["AutoSaveEnabled"] = config.AutoSaveEnabled;
+    j["AutoSaveIntervalMinutes"] = config.AutoSaveIntervalMinutes;
+    j["AutoSaveMaxVersions"] = config.AutoSaveMaxVersions;
 }
 
 inline void from_json(nlohmann::json j, EditorConfig& config) {
@@ -70,4 +77,7 @@ inline void from_json(nlohmann::json j, EditorConfig& config) {
     config.SnapToGrid = j.value("SnapToGrid", config.SnapToGrid);
     config.SnapToAngle = j.value("SnapToAngle", config.SnapToAngle);
     config.SnapAngle = j.value("SnapAngle", config.SnapAngle);
+    config.AutoSaveEnabled = j.value("AutoSaveEnabled", config.AutoSaveEnabled);
+    config.AutoSaveIntervalMinutes = j.value("AutoSaveIntervalMinutes", config.AutoSaveIntervalMinutes);
+    config.AutoSaveMaxVersions = j.value("AutoSaveMaxVersions", config.AutoSaveMaxVersions);
 }

--- a/src/editor/editor_layer.cpp
+++ b/src/editor/editor_layer.cpp
@@ -34,11 +34,24 @@
 
 #include <nfd.h>
 #include <ctime>
+#if defined(_WIN32)
+#include <process.h>
+#include <windows.h>
+#else
+#include <cerrno>
+#include <signal.h>
+#include <unistd.h>
+#endif
 
 EditorLayer::EditorLayer(moth_ui::Context& context, moth_graphics::graphics::IGraphics& graphics, EditorApplication* app)
     : m_app(app)
     , m_context(context)
     , m_graphics(graphics) {
+#if defined(_WIN32)
+    m_crashRecoveryPath = std::filesystem::temp_directory_path() / fmt::format("moth_editor_recovery_{}.moth", _getpid());
+#else
+    m_crashRecoveryPath = std::filesystem::temp_directory_path() / fmt::format("moth_editor_recovery_{}.moth", getpid());
+#endif
     LoadConfig();
 
     AddEditorPanel<EditorPanelConfig>(*this, false);
@@ -76,7 +89,7 @@ void EditorLayer::Update(uint32_t ticks) {
 
     if (m_config.AutoSaveEnabled && !m_currentLayoutPath.empty() && IsWorkPending()) {
         m_autoSaveAccumulatedMs += ticks;
-        uint32_t const intervalMs = static_cast<uint32_t>(m_config.AutoSaveIntervalMinutes) * 60u * 1000u;
+        uint32_t const intervalMs = static_cast<uint32_t>(std::clamp(m_config.AutoSaveIntervalMinutes, 1, 1440)) * 60u * 1000u;
         if (m_autoSaveAccumulatedMs >= intervalMs) {
             m_autoSaveAccumulatedMs = 0;
             AutoSave();
@@ -392,6 +405,7 @@ void EditorLayer::SaveLayout(std::filesystem::path const& path) {
         m_lastSaveActionIndex = m_actionIndex;
         m_currentLayoutPath = path;
         AddRecentFile(path);
+        DeleteCrashRecovery();
     }
 }
 
@@ -443,14 +457,62 @@ void EditorLayer::AutoSave() {
     }
 }
 
-std::filesystem::path EditorLayer::GetCrashRecoveryPath() {
-    return std::filesystem::temp_directory_path() / "moth_editor_recovery.moth";
+namespace {
+    bool IsProcessAlive(int pid) {
+#if defined(_WIN32)
+        HANDLE handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, static_cast<DWORD>(pid));
+        if (handle == nullptr) {
+            return false;
+        }
+        DWORD exitCode = 0;
+        bool const alive = GetExitCodeProcess(handle, &exitCode) && exitCode == STILL_ACTIVE;
+        CloseHandle(handle);
+        return alive;
+#else
+        return kill(pid, 0) == 0 || errno == EPERM;
+#endif
+    }
 }
 
 void EditorLayer::CheckCrashRecovery() {
+    // Scan the temp dir for recovery files from crashed instances.
+    // Skip any file whose PID is still alive — that instance is still running.
+    std::string const prefix = "moth_editor_recovery_";
+    std::string const ext = ".moth";
+    std::vector<std::filesystem::path> recoveryFiles;
     std::error_code ec;
-    if (!std::filesystem::exists(GetCrashRecoveryPath(), ec)) {
+    for (auto const& entry : std::filesystem::directory_iterator(std::filesystem::temp_directory_path(), ec)) {
+        if (!entry.is_regular_file(ec)) {
+            continue;
+        }
+        auto const name = entry.path().filename().string();
+        if (name.substr(0, prefix.size()) != prefix || entry.path().extension() != ext) {
+            continue;
+        }
+        // Extract the PID from the filename and skip if that process is still running
+        auto const pidStr = name.substr(prefix.size(), name.size() - prefix.size() - ext.size());
+        try {
+            if (IsProcessAlive(std::stoi(pidStr))) {
+                continue;
+            }
+        } catch (std::exception const&) {
+            // Filename doesn't contain a valid PID — treat it as a crash file
+        }
+        recoveryFiles.push_back(entry.path());
+    }
+    if (recoveryFiles.empty()) {
         return;
+    }
+
+    // Use the most recently modified file; silently discard the rest
+    auto const recoveryPath = *std::max_element(recoveryFiles.begin(), recoveryFiles.end(),
+        [&ec](std::filesystem::path const& a, std::filesystem::path const& b) {
+            return std::filesystem::last_write_time(a, ec) < std::filesystem::last_write_time(b, ec);
+        });
+    for (auto const& path : recoveryFiles) {
+        if (path != recoveryPath) {
+            std::filesystem::remove(path, ec);
+        }
     }
 
     m_confirmPrompt.SetTitle("Crash Recovery");
@@ -458,18 +520,15 @@ void EditorLayer::CheckCrashRecovery() {
     m_confirmPrompt.SetPositiveText("Restore");
     m_confirmPrompt.SetNegativeText("Discard");
     m_confirmPrompt.SetCancelText("");
-    m_confirmPrompt.SetPositiveAction([this]() {
-        auto const recoveryPath = GetCrashRecoveryPath();
+    m_confirmPrompt.SetPositiveAction([this, recoveryPath]() {
         std::shared_ptr<moth_ui::Layout> recoveredLayout;
         if (moth_ui::Layout::Load(recoveryPath, &recoveredLayout) == moth_ui::Layout::LoadResult::Success) {
-            // Restore the original file path stored in extra data
             std::filesystem::path originalPath;
             auto& extraData = recoveredLayout->GetExtraData();
             if (extraData.contains("crash_recovery_original_path")) {
                 originalPath = extraData["crash_recovery_original_path"].get<std::string>();
                 extraData.erase("crash_recovery_original_path");
             }
-
             m_rootLayout = recoveredLayout;
             m_currentLayoutPath = originalPath;
             m_selectedFrame = 0;
@@ -483,10 +542,12 @@ void EditorLayer::CheckCrashRecovery() {
             // Mark as having unsaved work since this is a recovery, not a real save
             m_lastSaveActionIndex = m_actionIndex - 1;
         }
-        DeleteCrashRecovery();
+        std::error_code removeEc;
+        std::filesystem::remove(recoveryPath, removeEc);
     });
-    m_confirmPrompt.SetNegativeAction([]() {
-        DeleteCrashRecovery();
+    m_confirmPrompt.SetNegativeAction([recoveryPath]() {
+        std::error_code removeEc;
+        std::filesystem::remove(recoveryPath, removeEc);
     });
     m_confirmPrompt.SetCancelAction(nullptr);
     m_confirmPrompt.Open();
@@ -500,13 +561,13 @@ void EditorLayer::SaveCrashRecovery() {
     m_rootLayout->GetExtraData()["crash_recovery_original_path"] = m_currentLayoutPath.string();
     moth_ui::Layout::SaveOptions saveOptions;
     saveOptions.pretty = false;
-    m_rootLayout->Save(GetCrashRecoveryPath(), saveOptions);
+    m_rootLayout->Save(m_crashRecoveryPath, saveOptions);
     m_rootLayout->GetExtraData().erase("crash_recovery_original_path");
 }
 
-void EditorLayer::DeleteCrashRecovery() { // NOLINT(readability-convert-member-functions-to-static)
+void EditorLayer::DeleteCrashRecovery() {
     std::error_code ec;
-    std::filesystem::remove(GetCrashRecoveryPath(), ec);
+    std::filesystem::remove(m_crashRecoveryPath, ec);
 }
 
 void EditorLayer::Rebuild() {

--- a/src/editor/editor_layer.cpp
+++ b/src/editor/editor_layer.cpp
@@ -432,7 +432,9 @@ void EditorLayer::AutoSave() {
 
     moth_ui::Layout::SaveOptions saveOptions;
     saveOptions.pretty = true;
-    m_rootLayout->Save(autosavePath, saveOptions);
+    if (!m_rootLayout->Save(autosavePath, saveOptions)) {
+        return;
+    }
 
     // Collect existing autosave files for this layout
     std::string const prefix = stem + ".autosave_";
@@ -505,16 +507,12 @@ void EditorLayer::CheckCrashRecovery() {
         return;
     }
 
-    // Use the most recently modified file; silently discard the rest
+    // Use the most recently modified file; leave others in place — they will be offered
+    // on subsequent startups until the user has had a chance to review each one
     auto const recoveryPath = *std::max_element(recoveryFiles.begin(), recoveryFiles.end(),
         [&ec](std::filesystem::path const& a, std::filesystem::path const& b) {
             return std::filesystem::last_write_time(a, ec) < std::filesystem::last_write_time(b, ec);
         });
-    for (auto const& path : recoveryFiles) {
-        if (path != recoveryPath) {
-            std::filesystem::remove(path, ec);
-        }
-    }
 
     m_confirmPrompt.SetTitle("Crash Recovery");
     m_confirmPrompt.SetMessage("A crash recovery file was found. Would you like to restore your previous session?");

--- a/src/editor/editor_layer.cpp
+++ b/src/editor/editor_layer.cpp
@@ -254,6 +254,7 @@ void EditorLayer::DebugDraw() {
 void EditorLayer::OnAddedToStack(moth_ui::LayerStack* layerStack) {
     Layer::OnAddedToStack(layerStack);
     NewLayout();
+    CheckCrashRecovery();
 }
 
 void EditorLayer::OnRemovedFromStack() {
@@ -272,6 +273,9 @@ void EditorLayer::AddEditAction(std::unique_ptr<IEditorAction>&& editAction) {
     }
     m_editActions.push_back(std::move(editAction));
     ++m_actionIndex;
+    if (IsWorkPending()) {
+        SaveCrashRecovery();
+    }
 }
 
 void EditorLayer::SetSelectedFrame(int frameNo) {
@@ -437,6 +441,72 @@ void EditorLayer::AutoSave() {
         std::filesystem::remove(autosaveFiles.front(), ec);
         autosaveFiles.erase(autosaveFiles.begin());
     }
+}
+
+std::filesystem::path EditorLayer::GetCrashRecoveryPath() {
+    return std::filesystem::temp_directory_path() / "moth_editor_recovery.moth";
+}
+
+void EditorLayer::CheckCrashRecovery() {
+    std::error_code ec;
+    if (!std::filesystem::exists(GetCrashRecoveryPath(), ec)) {
+        return;
+    }
+
+    m_confirmPrompt.SetTitle("Crash Recovery");
+    m_confirmPrompt.SetMessage("A crash recovery file was found. Would you like to restore your previous session?");
+    m_confirmPrompt.SetPositiveText("Restore");
+    m_confirmPrompt.SetNegativeText("Discard");
+    m_confirmPrompt.SetCancelText("");
+    m_confirmPrompt.SetPositiveAction([this]() {
+        auto const recoveryPath = GetCrashRecoveryPath();
+        std::shared_ptr<moth_ui::Layout> recoveredLayout;
+        if (moth_ui::Layout::Load(recoveryPath, &recoveredLayout) == moth_ui::Layout::LoadResult::Success) {
+            // Restore the original file path stored in extra data
+            std::filesystem::path originalPath;
+            auto& extraData = recoveredLayout->GetExtraData();
+            if (extraData.contains("crash_recovery_original_path")) {
+                originalPath = extraData["crash_recovery_original_path"].get<std::string>();
+                extraData.erase("crash_recovery_original_path");
+            }
+
+            m_rootLayout = recoveredLayout;
+            m_currentLayoutPath = originalPath;
+            m_selectedFrame = 0;
+            ClearSelection();
+            ClearEditActions();
+            m_lockedNodes.clear();
+            Rebuild();
+            for (auto&& [panelId, panel] : m_panels) {
+                panel->OnLayoutLoaded();
+            }
+            // Mark as having unsaved work since this is a recovery, not a real save
+            m_lastSaveActionIndex = m_actionIndex - 1;
+        }
+        DeleteCrashRecovery();
+    });
+    m_confirmPrompt.SetNegativeAction([]() {
+        DeleteCrashRecovery();
+    });
+    m_confirmPrompt.SetCancelAction(nullptr);
+    m_confirmPrompt.Open();
+}
+
+void EditorLayer::SaveCrashRecovery() {
+    if (m_rootLayout == nullptr) {
+        return;
+    }
+    // Temporarily stash the original path in extra data so it can be restored on recovery
+    m_rootLayout->GetExtraData()["crash_recovery_original_path"] = m_currentLayoutPath.string();
+    moth_ui::Layout::SaveOptions saveOptions;
+    saveOptions.pretty = false;
+    m_rootLayout->Save(GetCrashRecoveryPath(), saveOptions);
+    m_rootLayout->GetExtraData().erase("crash_recovery_original_path");
+}
+
+void EditorLayer::DeleteCrashRecovery() { // NOLINT(readability-convert-member-functions-to-static)
+    std::error_code ec;
+    std::filesystem::remove(GetCrashRecoveryPath(), ec);
 }
 
 void EditorLayer::Rebuild() {
@@ -947,6 +1017,7 @@ void EditorLayer::Shutdown() {
     for (auto&& [panelId, panel] : m_panels) {
         panel->OnShutdown();
     }
+    DeleteCrashRecovery();
     SaveConfig();
     m_layerStack->FireEvent(moth_graphics::EventQuit());
 }

--- a/src/editor/editor_layer.cpp
+++ b/src/editor/editor_layer.cpp
@@ -36,6 +36,7 @@
 #include <ctime>
 #if defined(_WIN32)
 #include <process.h>
+#define NOMINMAX
 #include <windows.h>
 #else
 #include <cerrno>

--- a/src/editor/editor_layer.cpp
+++ b/src/editor/editor_layer.cpp
@@ -287,9 +287,7 @@ void EditorLayer::AddEditAction(std::unique_ptr<IEditorAction>&& editAction) {
     }
     m_editActions.push_back(std::move(editAction));
     ++m_actionIndex;
-    if (IsWorkPending()) {
-        SaveCrashRecovery();
-    }
+    SyncCrashRecovery();
 }
 
 void EditorLayer::SetSelectedFrame(int frameNo) {
@@ -310,6 +308,7 @@ void EditorLayer::UndoEditAction() {
         m_editActions[m_actionIndex]->Undo();
         --m_actionIndex;
         Refresh();
+        SyncCrashRecovery();
     }
 }
 
@@ -318,6 +317,7 @@ void EditorLayer::RedoEditAction() {
         ++m_actionIndex;
         m_editActions[m_actionIndex]->Do();
         Refresh();
+        SyncCrashRecovery();
     }
 }
 
@@ -335,8 +335,9 @@ void EditorLayer::NewLayout(bool discard) {
         m_confirmPrompt.SetNegativeText("Discard and New");
         m_confirmPrompt.SetCancelText("Cancel");
         m_confirmPrompt.SetPositiveAction([this]() {
-            SaveLayout(m_currentLayoutPath.c_str());
-            NewLayout();
+            if (SaveLayout(m_currentLayoutPath.c_str())) {
+                NewLayout();
+            }
         });
         m_confirmPrompt.SetNegativeAction([this]() {
             NewLayout(true);
@@ -366,8 +367,9 @@ void EditorLayer::LoadLayout(std::filesystem::path const& path, bool discard) {
         m_confirmPrompt.SetNegativeText("Discard and Load");
         m_confirmPrompt.SetCancelText("Cancel");
         m_confirmPrompt.SetPositiveAction([this, path]() {
-            SaveLayout(m_currentLayoutPath);
-            LoadLayout(path);
+            if (SaveLayout(m_currentLayoutPath)) {
+                LoadLayout(path);
+            }
         });
         m_confirmPrompt.SetNegativeAction([this, path]() {
             LoadLayout(path, true);
@@ -399,15 +401,17 @@ void EditorLayer::LoadLayout(std::filesystem::path const& path, bool discard) {
     }
 }
 
-void EditorLayer::SaveLayout(std::filesystem::path const& path) {
+bool EditorLayer::SaveLayout(std::filesystem::path const& path) {
     moth_ui::Layout::SaveOptions saveOptions;
     saveOptions.pretty = true;
-    if (m_rootLayout->Save(path, saveOptions)) {
-        m_lastSaveActionIndex = m_actionIndex;
-        m_currentLayoutPath = path;
-        AddRecentFile(path);
-        DeleteCrashRecovery();
+    if (!m_rootLayout->Save(path, saveOptions)) {
+        return false;
     }
+    m_lastSaveActionIndex = m_actionIndex;
+    m_currentLayoutPath = path;
+    AddRecentFile(path);
+    DeleteCrashRecovery();
+    return true;
 }
 
 void EditorLayer::AutoSave() {
@@ -540,9 +544,11 @@ void EditorLayer::CheckCrashRecovery() {
             }
             // Mark as having unsaved work since this is a recovery, not a real save
             m_lastSaveActionIndex = m_actionIndex - 1;
+            std::error_code removeEc;
+            std::filesystem::remove(recoveryPath, removeEc);
+        } else {
+            ShowError(fmt::format("Failed to load crash recovery file: {}", recoveryPath.string()));
         }
-        std::error_code removeEc;
-        std::filesystem::remove(recoveryPath, removeEc);
     });
     m_confirmPrompt.SetNegativeAction([recoveryPath]() {
         std::error_code removeEc;
@@ -560,13 +566,25 @@ void EditorLayer::SaveCrashRecovery() {
     m_rootLayout->GetExtraData()["crash_recovery_original_path"] = m_currentLayoutPath.string();
     moth_ui::Layout::SaveOptions saveOptions;
     saveOptions.pretty = false;
-    m_rootLayout->Save(m_crashRecoveryPath, saveOptions);
-    m_rootLayout->GetExtraData().erase("crash_recovery_original_path");
+    if (m_rootLayout->Save(m_crashRecoveryPath, saveOptions)) {
+        m_rootLayout->GetExtraData().erase("crash_recovery_original_path");
+    } else {
+        m_rootLayout->GetExtraData().erase("crash_recovery_original_path");
+        ShowError(fmt::format("Failed to write crash recovery file: {}", m_crashRecoveryPath.string()));
+    }
 }
 
 void EditorLayer::DeleteCrashRecovery() {
     std::error_code ec;
     std::filesystem::remove(m_crashRecoveryPath, ec);
+}
+
+void EditorLayer::SyncCrashRecovery() {
+    if (IsWorkPending()) {
+        SaveCrashRecovery();
+    } else {
+        DeleteCrashRecovery();
+    }
 }
 
 void EditorLayer::Rebuild() {
@@ -803,8 +821,9 @@ bool EditorLayer::OnRequestQuitEvent(moth_graphics::EventRequestQuit const& even
                     Shutdown();
                 }
             } else {
-                SaveLayout(m_currentLayoutPath);
-                Shutdown();
+                if (SaveLayout(m_currentLayoutPath)) {
+                    Shutdown();
+                }
             }
         });
         m_confirmPrompt.SetNegativeAction([this]() {

--- a/src/editor/editor_layer.cpp
+++ b/src/editor/editor_layer.cpp
@@ -33,6 +33,7 @@
 #include "texture_packer.h"
 
 #include <nfd.h>
+#include <ctime>
 
 EditorLayer::EditorLayer(moth_ui::Context& context, moth_graphics::graphics::IGraphics& graphics, EditorApplication* app)
     : m_app(app)
@@ -71,6 +72,17 @@ bool EditorLayer::OnEvent(moth_ui::Event const& event) {
 void EditorLayer::Update(uint32_t ticks) {
     for (auto& [type, panel] : m_panels) {
         panel->Update(ticks);
+    }
+
+    if (m_config.AutoSaveEnabled && !m_currentLayoutPath.empty() && IsWorkPending()) {
+        m_autoSaveAccumulatedMs += ticks;
+        uint32_t const intervalMs = static_cast<uint32_t>(m_config.AutoSaveIntervalMinutes) * 60u * 1000u;
+        if (m_autoSaveAccumulatedMs >= intervalMs) {
+            m_autoSaveAccumulatedMs = 0;
+            AutoSave();
+        }
+    } else {
+        m_autoSaveAccumulatedMs = 0;
     }
 
     auto const windowTitle = fmt::format("{}{}", m_currentLayoutPath.empty() ? "New Layout" : m_currentLayoutPath.string(), IsWorkPending() ? " *" : "");
@@ -170,6 +182,16 @@ void EditorLayer::DrawMainMenu() {
             }
             if (ImGui::MenuItem("Save Layout As", "Ctrl+Shift+S")) {
                 MenuFuncSaveLayoutAs();
+            }
+            ImGui::Separator();
+            ImGui::Checkbox("Autosave", &m_config.AutoSaveEnabled);
+            if (m_config.AutoSaveEnabled) {
+                ImGui::SetNextItemWidth(80.0f);
+                ImGui::InputInt("Interval (min)", &m_config.AutoSaveIntervalMinutes);
+                m_config.AutoSaveIntervalMinutes = std::max(1, m_config.AutoSaveIntervalMinutes);
+                ImGui::SetNextItemWidth(80.0f);
+                ImGui::InputInt("Max Versions", &m_config.AutoSaveMaxVersions);
+                m_config.AutoSaveMaxVersions = std::max(1, m_config.AutoSaveMaxVersions);
             }
             ImGui::Separator();
             if (ImGui::MenuItem("Exit")) {
@@ -366,6 +388,54 @@ void EditorLayer::SaveLayout(std::filesystem::path const& path) {
         m_lastSaveActionIndex = m_actionIndex;
         m_currentLayoutPath = path;
         AddRecentFile(path);
+    }
+}
+
+void EditorLayer::AutoSave() {
+    if (m_currentLayoutPath.empty()) {
+        return;
+    }
+
+    std::time_t const now = std::time(nullptr);
+    std::tm localTime{};
+#if defined(_WIN32)
+    localtime_s(&localTime, &now);
+#else
+    localtime_r(&now, &localTime);
+#endif
+    char timeBuf[32];
+    std::strftime(timeBuf, sizeof(timeBuf), "%Y%m%d_%H%M%S", &localTime);
+
+    auto const dir = m_currentLayoutPath.parent_path();
+    auto const stem = m_currentLayoutPath.stem().string();
+    auto const ext = m_currentLayoutPath.extension().string();
+    auto const autosavePath = dir / (stem + ".autosave_" + timeBuf + ext);
+
+    moth_ui::Layout::SaveOptions saveOptions;
+    saveOptions.pretty = true;
+    m_rootLayout->Save(autosavePath, saveOptions);
+
+    // Collect existing autosave files for this layout
+    std::string const prefix = stem + ".autosave_";
+    std::vector<std::filesystem::path> autosaveFiles;
+    std::error_code ec;
+    for (auto const& entry : std::filesystem::directory_iterator(dir, ec)) {
+        if (!entry.is_regular_file(ec)) {
+            continue;
+        }
+        auto const name = entry.path().filename().string();
+        if (name.substr(0, prefix.size()) == prefix && entry.path().extension() == ext) {
+            autosaveFiles.push_back(entry.path());
+        }
+    }
+
+    // Sort ascending by name — timestamps are fixed-width so lexicographic order = chronological
+    std::sort(autosaveFiles.begin(), autosaveFiles.end());
+
+    int const maxVersions = std::max(1, m_config.AutoSaveMaxVersions);
+    while (static_cast<int>(autosaveFiles.size()) > maxVersions) {
+        std::filesystem::remove(autosaveFiles.front(), ec);
+        autosaveFiles.erase(autosaveFiles.begin());
     }
 }
 

--- a/src/editor/editor_layer.h
+++ b/src/editor/editor_layer.h
@@ -197,10 +197,11 @@ private:
     void SaveLayout(std::filesystem::path const& path);
     void AutoSave();
 
-    static std::filesystem::path GetCrashRecoveryPath();
-    static void DeleteCrashRecovery();
     void CheckCrashRecovery();
     void SaveCrashRecovery();
+    void DeleteCrashRecovery();
+
+    std::filesystem::path m_crashRecoveryPath;
 
     void Rebuild();
 

--- a/src/editor/editor_layer.h
+++ b/src/editor/editor_layer.h
@@ -196,6 +196,12 @@ private:
 
     void SaveLayout(std::filesystem::path const& path);
     void AutoSave();
+
+    static std::filesystem::path GetCrashRecoveryPath();
+    static void DeleteCrashRecovery();
+    void CheckCrashRecovery();
+    void SaveCrashRecovery();
+
     void Rebuild();
 
     void MoveSelectionUp();

--- a/src/editor/editor_layer.h
+++ b/src/editor/editor_layer.h
@@ -194,12 +194,13 @@ private:
     void RedoEditAction();
     void ClearEditActions();
 
-    void SaveLayout(std::filesystem::path const& path);
+    bool SaveLayout(std::filesystem::path const& path);
     void AutoSave();
 
     void CheckCrashRecovery();
     void SaveCrashRecovery();
     void DeleteCrashRecovery();
+    void SyncCrashRecovery();
 
     std::filesystem::path m_crashRecoveryPath;
 

--- a/src/editor/editor_layer.h
+++ b/src/editor/editor_layer.h
@@ -177,6 +177,7 @@ private:
     std::vector<std::unique_ptr<IEditorAction>> m_editActions;
     int m_actionIndex = -1;
     int m_lastSaveActionIndex = -1;
+    uint32_t m_autoSaveAccumulatedMs = 0;
     bool IsWorkPending() const { return m_lastSaveActionIndex != m_actionIndex; }
     ConfirmPrompt m_confirmPrompt;
 
@@ -194,6 +195,7 @@ private:
     void ClearEditActions();
 
     void SaveLayout(std::filesystem::path const& path);
+    void AutoSave();
     void Rebuild();
 
     void MoveSelectionUp();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autosave: periodic automatic saves with configurable enable, interval (clamped), and max retained versions; controls added to File menu.
  * Crash recovery: detects unsaved work after a crash (skips active processes), offers restore or discard, and restores recovered layouts.

* **Chores**
  * Updated graphics dependency to a newer compatible version.
  * Adjusted CI workflow triggers (removed certain push trigger).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->