### PR TITLE
Fix NFD file filter strings and improve editing state tracking

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,7 +47,3 @@ jobs:
         cmake --preset ${{ matrix.configure_preset }}
         cmake --build --preset conan-release --config Release
 
-    - name: Build example
-      shell: bash
-      working-directory: example
-      run: conan create . -pr ../.conan/profile -s build_type=Release --build=missing

--- a/src/editor/panels/editor_panel_animation.cpp
+++ b/src/editor/panels/editor_panel_animation.cpp
@@ -570,13 +570,19 @@ bool EditorPanelAnimation::DrawClipPopup() {
         }
 
         if (clipContext != nullptr && ImGui::BeginMenu("Edit")) {
+            static char nameBuf[1024];
             if (!m_pendingClipEdit.has_value()) {
                 m_pendingClipEdit = EditContext<AnimationClip>(clipContext->clip);
+                // Initialise buffer once so ImGui owns it during editing.
+                ImFormatString(nameBuf, IM_ARRAYSIZE(nameBuf), "%s", m_pendingClipEdit->mutableValue.m_name.c_str());
             }
 
-            static char nameBuf[1024];
-            ImFormatString(nameBuf, IM_ARRAYSIZE(nameBuf), "%s", m_pendingClipEdit->mutableValue.m_name.c_str());
             if (ImGui::InputText("Name", nameBuf, sizeof(nameBuf))) {
+                m_pendingClipEdit->mutableValue.m_name = std::string(nameBuf);
+            }
+            // Sync on any deactivation: Escape reverts nameBuf via ImGui so this
+            // correctly cancels (HasChanged becomes false); Tab/click-away commits.
+            if (ImGui::IsItemDeactivated()) {
                 m_pendingClipEdit->mutableValue.m_name = std::string(nameBuf);
             }
 

--- a/src/editor/panels/editor_panel_animation.cpp
+++ b/src/editor/panels/editor_panel_animation.cpp
@@ -769,6 +769,9 @@ bool EditorPanelAnimation::DrawEventPopup() {
             if (ImGui::InputText("Event Name", nameBuf, sizeof(nameBuf))) {
                 m_pendingEventEdit->mutableValue.m_name = std::string(nameBuf);
             }
+            if (ImGui::IsItemDeactivated()) {
+                m_pendingEventEdit->mutableValue.m_name = std::string(nameBuf);
+            }
             ImGui::EndMenu();
         }
 

--- a/src/editor/panels/editor_panel_elements.cpp
+++ b/src/editor/panels/editor_panel_elements.cpp
@@ -24,7 +24,7 @@ namespace {
             [](EditorLayer& editorLayer) {
                 auto const currentPath = std::filesystem::current_path().string();
                 nfdchar_t* outPath = NULL;
-                nfdresult_t result = NFD_OpenDialog("jpg, jpeg, png, bmp", currentPath.c_str(), &outPath);
+                nfdresult_t result = NFD_OpenDialog("jpg,jpeg,png,bmp", currentPath.c_str(), &outPath);
 
                 if (result == NFD_OKAY) {
                     std::filesystem::path filePath = outPath;

--- a/src/editor/panels/editor_panel_fonts.cpp
+++ b/src/editor/panels/editor_panel_fonts.cpp
@@ -78,9 +78,10 @@ void EditorPanelFonts::Draw() {
     if (ImGui::Button("Add Font", ImVec2(sideButtonW, 0))) {
         auto const currentPath = std::filesystem::current_path().string();
         nfdchar_t* outPath = NULL;
-        if (NFD_OpenDialog("ttf", currentPath.c_str(), &outPath) == NFD_OKAY) {
+        if (NFD_OpenDialog("ttf,otf", currentPath.c_str(), &outPath) == NFD_OKAY) {
             m_pendingFontPath = outPath;
-            NameBuffer[0] = 0;
+            auto const stem = m_pendingFontPath.stem().string();
+            std::snprintf(NameBuffer, sizeof(NameBuffer), "%s", stem.c_str());
             ImGui::OpenPopup("Name Font");
         }
     }

--- a/src/editor/panels/editor_panel_fonts.cpp
+++ b/src/editor/panels/editor_panel_fonts.cpp
@@ -80,6 +80,7 @@ void EditorPanelFonts::Draw() {
         nfdchar_t* outPath = NULL;
         if (NFD_OpenDialog("ttf,otf", currentPath.c_str(), &outPath) == NFD_OKAY) {
             m_pendingFontPath = outPath;
+            NFD_Free(outPath);
             auto const stem = m_pendingFontPath.stem().string();
             std::snprintf(NameBuffer, sizeof(NameBuffer), "%s", stem.c_str());
             ImGui::OpenPopup("Name Font");

--- a/src/editor/panels/editor_panel_properties.cpp
+++ b/src/editor/panels/editor_panel_properties.cpp
@@ -434,7 +434,7 @@ void EditorPanelProperties::DrawImageProperties(std::shared_ptr<moth_ui::NodeIma
     if (ImGui::Button("Load Image..")) {
         auto const currentPath = std::filesystem::current_path().string();
         nfdchar_t* outPath = NULL;
-        nfdresult_t result = NFD_OpenDialog("jpg, jpeg, png, bmp", currentPath.c_str(), &outPath);
+        nfdresult_t result = NFD_OpenDialog("jpg,jpeg,png,bmp", currentPath.c_str(), &outPath);
 
         if (result == NFD_OKAY) {
             std::filesystem::path filePath = outPath;

--- a/src/editor/panels/editor_panel_properties.cpp
+++ b/src/editor/panels/editor_panel_properties.cpp
@@ -151,6 +151,13 @@ void EditorPanelProperties::DrawCommonProperties(std::shared_ptr<moth_ui::Node> 
         ImGui::Text("%s", sizeText.c_str());
     }
 
+    // Bounds uses the legacy OnInputFocus path intentionally: InputElement("Bounds", ...)
+    // is a composite widget (4×2 InputFloat sub-items) so ImGui::GetItemID() only refers
+    // to the last sub-input, making IsItemActivated()/IsItemDeactivatedAfterEdit() unreliable
+    // for the whole group. BeginEditBounds is safe to call on consecutive Changed frames —
+    // its internal guard prevents duplicate undo sessions — and EndEditBounds is committed
+    // when the context is flushed (via IsItemActivated() on the next PropertiesInput, or on
+    // selection change in EndPanel).
     auto valueBuffer = GetBufferForValue(node->GetLayoutRect());
     auto const inputContext = InputElement("Bounds", valueBuffer);
     if (inputContext.Changed) {

--- a/src/editor/panels/editor_panel_properties.cpp
+++ b/src/editor/panels/editor_panel_properties.cpp
@@ -42,15 +42,12 @@ bool EditorPanelProperties::BeginPanel() {
         m_currentSelection = *std::begin(selection);
     }
 
-    BeginEdits();
     bool ret = EditorPanel::BeginPanel();
     ImGui::PushID(m_currentSelection.get());
     return ret;
 }
 
 void EditorPanelProperties::EndPanel() {
-    EndEdits();
-
     if (m_lastSelection && m_currentSelection != m_lastSelection) {
         CommitEditContext();
     }

--- a/src/editor/properties_elements.cpp
+++ b/src/editor/properties_elements.cpp
@@ -2,7 +2,6 @@
 #include "properties_elements.h"
 
 std::unique_ptr<PropertyEditContextBase> m_currentEditContext;
-ImGuiID m_editingID;
 
 ImGuiID GetCurrentEditFocusID() {
     if (m_currentEditContext) {
@@ -15,15 +14,5 @@ void CommitEditContext() {
     if (m_currentEditContext) {
         m_currentEditContext->Commit();
         m_currentEditContext.reset();
-    }
-}
-
-void BeginEdits() {
-    m_editingID = 0;
-}
-
-void EndEdits() {
-    if (m_editingID != GetCurrentEditFocusID()) {
-        CommitEditContext();
     }
 }

--- a/src/editor/properties_elements.h
+++ b/src/editor/properties_elements.h
@@ -312,6 +312,10 @@ bool PropertiesInput(char const* label, T current, std::function<void(T)> const&
                     }
                 }
                 CommitEditContext();
+            } else if (ImGui::IsItemDeactivated() && m_currentEditContext && m_currentEditContext->GetID() == ImGui::GetItemID()) {
+                // Cancelled (e.g. Escape): discard context without committing so no
+                // spurious undo action is created from the partially-typed value.
+                m_currentEditContext.reset();
             }
         }
     }
@@ -365,6 +369,8 @@ inline bool PropertiesInput(char const* label, char const* text, int lines, std:
                 ctx->UpdateValue(valueBuffer.Buffer);
             }
             CommitEditContext();
+        } else if (ImGui::IsItemDeactivated() && m_currentEditContext && m_currentEditContext->GetID() == ImGui::GetItemID()) {
+            m_currentEditContext.reset();
         }
     }
 

--- a/src/editor/properties_elements.h
+++ b/src/editor/properties_elements.h
@@ -109,54 +109,69 @@ template <class SourceType>
 struct InputContext {
     bool Changed;
     bool Focused;
+    bool DeactivatedAfterEdit;
+    bool Deactivated;
     InputBuffer<SourceType> ValueBuffer;
 };
 
 inline InputContext<bool> InputElement(char const* label, InputBuffer<bool> valueBuffer) {
     bool changed = ImGui::Checkbox(label, valueBuffer.Buffer);
-    bool focused = false;
-    return { changed, focused, valueBuffer };
+    return { changed, false, false, false, valueBuffer };
 }
 
 inline InputContext<int> InputElement(char const* label, InputBuffer<int> valueBuffer) {
     bool changed = ImGui::InputInt(label, valueBuffer.Buffer, 0);
     bool focused = ImGui::IsItemFocused();
-    return { changed, focused, valueBuffer };
+    bool deactivatedAfterEdit = ImGui::IsItemDeactivatedAfterEdit();
+    bool deactivated = ImGui::IsItemDeactivated();
+    return { changed, focused, deactivatedAfterEdit, deactivated, valueBuffer };
 }
 
 inline InputContext<float> InputElement(char const* label, InputBuffer<float> valueBuffer) {
     bool changed = ImGui::InputFloat(label, valueBuffer.Buffer);
     bool focused = ImGui::IsItemFocused();
-    return { changed, focused, valueBuffer };
+    bool deactivatedAfterEdit = ImGui::IsItemDeactivatedAfterEdit();
+    bool deactivated = ImGui::IsItemDeactivated();
+    return { changed, focused, deactivatedAfterEdit, deactivated, valueBuffer };
 }
 
 inline InputContext<char const*> InputElement(char const* label, InputBuffer<char const*> valueBuffer) {
     bool changed = ImGui::InputText(label, valueBuffer.Buffer, valueBuffer.Size - 1);
     bool focused = ImGui::IsItemFocused();
-    return { changed, focused, valueBuffer };
+    bool deactivatedAfterEdit = ImGui::IsItemDeactivatedAfterEdit();
+    bool deactivated = ImGui::IsItemDeactivated();
+    return { changed, focused, deactivatedAfterEdit, deactivated, valueBuffer };
 }
 
 inline InputContext<moth_ui::IntVec2> InputElement(char const* label, InputBuffer<moth_ui::IntVec2> valueBuffer) {
     bool changed = ImGui::InputInt2(label, valueBuffer.Buffer->data, 0);
     bool focused = ImGui::IsItemFocused();
-    return { changed, focused, valueBuffer };
+    bool deactivatedAfterEdit = ImGui::IsItemDeactivatedAfterEdit();
+    bool deactivated = ImGui::IsItemDeactivated();
+    return { changed, focused, deactivatedAfterEdit, deactivated, valueBuffer };
 }
 
 inline InputContext<moth_ui::FloatVec2> InputElement(char const* label, InputBuffer<moth_ui::FloatVec2> valueBuffer) {
     bool changed = ImGui::InputFloat2(label, valueBuffer.Buffer->data, "%.3f");
     bool focused = ImGui::IsItemFocused();
-    return { changed, focused, valueBuffer };
+    bool deactivatedAfterEdit = ImGui::IsItemDeactivatedAfterEdit();
+    bool deactivated = ImGui::IsItemDeactivated();
+    return { changed, focused, deactivatedAfterEdit, deactivated, valueBuffer };
 }
 
 inline InputContext<moth_ui::Color> InputElement(char const* label, InputBuffer<moth_ui::Color> valueBuffer) {
     bool changed = ImGui::ColorEdit4(label, valueBuffer.Buffer->data, ImGuiColorEditFlags_DisplayHex);
     bool focused = ImGui::IsItemFocused();
-    return { changed, focused, valueBuffer };
+    bool deactivatedAfterEdit = ImGui::IsItemDeactivatedAfterEdit();
+    bool deactivated = ImGui::IsItemDeactivated();
+    return { changed, focused, deactivatedAfterEdit, deactivated, valueBuffer };
 }
 
 inline InputContext<moth_ui::LayoutRect> InputElement(char const* label, InputBuffer<moth_ui::LayoutRect> valueBuffer) {
     bool changed = false;
     bool focused = false;
+    bool deactivatedAfterEdit = false;
+    bool deactivated = false;
 
     ImGui::Text("%s", label);
 
@@ -171,6 +186,8 @@ inline InputContext<moth_ui::LayoutRect> InputElement(char const* label, InputBu
             ImGui::SetNextItemWidth(-FLT_MIN);
             changed |= ImGui::InputFloat("##l", &rect.topLeft.x, 0, 0, "%.2f");
             focused |= ImGui::IsItemFocused();
+            deactivatedAfterEdit |= ImGui::IsItemDeactivatedAfterEdit();
+            deactivated |= ImGui::IsItemDeactivated();
 
             ImGui::TableNextColumn();
             ImGui::Text("T");
@@ -178,6 +195,8 @@ inline InputContext<moth_ui::LayoutRect> InputElement(char const* label, InputBu
             ImGui::SetNextItemWidth(-FLT_MIN);
             changed |= ImGui::InputFloat("##t", &rect.topLeft.y, 0, 0, "%.2f");
             focused |= ImGui::IsItemFocused();
+            deactivatedAfterEdit |= ImGui::IsItemDeactivatedAfterEdit();
+            deactivated |= ImGui::IsItemDeactivated();
 
             ImGui::TableNextRow();
             ImGui::TableNextColumn();
@@ -186,6 +205,8 @@ inline InputContext<moth_ui::LayoutRect> InputElement(char const* label, InputBu
             ImGui::SetNextItemWidth(-FLT_MIN);
             changed |= ImGui::InputFloat("##r", &rect.bottomRight.x, 0, 0, "%.2f");
             focused |= ImGui::IsItemFocused();
+            deactivatedAfterEdit |= ImGui::IsItemDeactivatedAfterEdit();
+            deactivated |= ImGui::IsItemDeactivated();
 
             ImGui::TableNextColumn();
             ImGui::Text("B");
@@ -193,6 +214,8 @@ inline InputContext<moth_ui::LayoutRect> InputElement(char const* label, InputBu
             ImGui::SetNextItemWidth(-FLT_MIN);
             changed |= ImGui::InputFloat("##b", &rect.bottomRight.y, 0, 0, "%.2f");
             focused |= ImGui::IsItemFocused();
+            deactivatedAfterEdit |= ImGui::IsItemDeactivatedAfterEdit();
+            deactivated |= ImGui::IsItemDeactivated();
 
             ImGui::EndTable();
         }
@@ -203,25 +226,35 @@ inline InputContext<moth_ui::LayoutRect> InputElement(char const* label, InputBu
     drawSection("Anchor", valueBuffer.Buffer->anchor);
     drawSection("Offset", valueBuffer.Buffer->offset);
 
-    return { changed, focused, valueBuffer };
+    return { changed, focused, deactivatedAfterEdit, deactivated, valueBuffer };
 }
 
 inline InputContext<moth_ui::IntRect> InputElement(char const* label, InputBuffer<moth_ui::IntRect> valueBuffer) {
     bool changed = false;
     bool focused = false;
+    bool deactivatedAfterEdit = false;
+    bool deactivated = false;
 
     if (ImGui::CollapsingHeader(label)) {
         changed |= ImGui::InputInt("Top", &valueBuffer.Buffer->topLeft.y, 0);
         focused |= ImGui::IsItemFocused();
+        deactivatedAfterEdit |= ImGui::IsItemDeactivatedAfterEdit();
+        deactivated |= ImGui::IsItemDeactivated();
         changed |= ImGui::InputInt("Left", &valueBuffer.Buffer->topLeft.x, 0);
         focused |= ImGui::IsItemFocused();
+        deactivatedAfterEdit |= ImGui::IsItemDeactivatedAfterEdit();
+        deactivated |= ImGui::IsItemDeactivated();
         changed |= ImGui::InputInt("Bottom", &valueBuffer.Buffer->bottomRight.y, 0);
         focused |= ImGui::IsItemFocused();
+        deactivatedAfterEdit |= ImGui::IsItemDeactivatedAfterEdit();
+        deactivated |= ImGui::IsItemDeactivated();
         changed |= ImGui::InputInt("Right", &valueBuffer.Buffer->bottomRight.x, 0);
         focused |= ImGui::IsItemFocused();
+        deactivatedAfterEdit |= ImGui::IsItemDeactivatedAfterEdit();
+        deactivated |= ImGui::IsItemDeactivated();
     }
 
-    return { changed, focused, valueBuffer };
+    return { changed, focused, deactivatedAfterEdit, deactivated, valueBuffer };
 }
 
 template <typename T, typename F = std::function<void(T, T)>, std::enable_if_t<std::is_enum_v<T>, bool> = true>
@@ -250,7 +283,7 @@ InputContext<T> InputElement(char const* label, InputBuffer<T> valueBuffer) {
         ImGui::EndCombo();
     }
 
-    return { changed, focused, valueBuffer };
+    return { changed, focused, false, false, valueBuffer };
 }
 
 
@@ -317,13 +350,13 @@ bool PropertiesInput(char const* label, T current, std::function<void(T)> const&
                 }
             }
 
-            // Deactivation checks compare against widgetId, which equals GetItemID()
-            // for single-item widgets so they commit/cancel on the correct frame.
-            // For composite widgets the last sub-item's ID won't match widgetId unless
-            // the user happened to leave via that last field, so composite commits are
-            // deferred to the next IsItemActivated() call (CommitEditContext()) or to
-            // the selection-change flush in EndPanel — both are reliable.
-            if (ImGui::IsItemDeactivatedAfterEdit() && m_currentEditContext && m_currentEditContext->GetID() == widgetId) {
+            // inputContext.DeactivatedAfterEdit / Deactivated are OR-accumulated across
+            // every child by each InputElement overload, so composite widgets (LayoutRect,
+            // IntRect) commit/cancel when *any* child loses focus — not just the last one.
+            // The !inputContext.Focused guard prevents a premature commit when the user
+            // tabs between children of the same composite (one child deactivates while
+            // another gains focus in the same frame).
+            if (inputContext.DeactivatedAfterEdit && !inputContext.Focused && m_currentEditContext && m_currentEditContext->GetID() == widgetId) {
                 auto* ctx = dynamic_cast<PropertyEditContext<T>*>(m_currentEditContext.get());
                 if (ctx != nullptr) {
                     if constexpr (std::is_same_v<T, char const*>) {
@@ -333,7 +366,7 @@ bool PropertiesInput(char const* label, T current, std::function<void(T)> const&
                     }
                 }
                 CommitEditContext();
-            } else if (ImGui::IsItemDeactivated() && m_currentEditContext && m_currentEditContext->GetID() == widgetId) {
+            } else if (inputContext.Deactivated && !inputContext.Focused && m_currentEditContext && m_currentEditContext->GetID() == widgetId) {
                 // Cancelled (e.g. Escape): discard without committing.
                 m_currentEditContext.reset();
             }

--- a/src/editor/properties_elements.h
+++ b/src/editor/properties_elements.h
@@ -9,9 +9,12 @@ public:
     virtual ~PropertyEditContextBase() = default;
     ImGuiID GetID() const { return m_id; }
     virtual void Commit() = 0;
+    void SetHadDeactivatedAfterEdit() { m_hadDeactivatedAfterEdit = true; }
+    bool HadDeactivatedAfterEdit() const { return m_hadDeactivatedAfterEdit; }
 
 protected:
     ImGuiID m_id;
+    bool m_hadDeactivatedAfterEdit = false;
 };
 template <class T>
 class PropertyEditContext : public PropertyEditContextBase {
@@ -116,7 +119,9 @@ struct InputContext {
 
 inline InputContext<bool> InputElement(char const* label, InputBuffer<bool> valueBuffer) {
     bool changed = ImGui::Checkbox(label, valueBuffer.Buffer);
-    return { changed, false, false, false, valueBuffer };
+    bool deactivatedAfterEdit = ImGui::IsItemDeactivatedAfterEdit();
+    bool deactivated = ImGui::IsItemDeactivated();
+    return { changed, false, deactivatedAfterEdit, deactivated, valueBuffer };
 }
 
 inline InputContext<int> InputElement(char const* label, InputBuffer<int> valueBuffer) {
@@ -356,6 +361,14 @@ bool PropertiesInput(char const* label, T current, std::function<void(T)> const&
             // The !inputContext.Focused guard prevents a premature commit when the user
             // tabs between children of the same composite (one child deactivates while
             // another gains focus in the same frame).
+            //
+            // Track whether any child has been successfully edited this session so that
+            // the Deactivated branch (e.g. tabbing out of an unedited trailing field) can
+            // commit rather than discard the earlier edits.
+            if (inputContext.DeactivatedAfterEdit && m_currentEditContext && m_currentEditContext->GetID() == widgetId) {
+                m_currentEditContext->SetHadDeactivatedAfterEdit();
+            }
+
             if (inputContext.DeactivatedAfterEdit && !inputContext.Focused && m_currentEditContext && m_currentEditContext->GetID() == widgetId) {
                 auto* ctx = dynamic_cast<PropertyEditContext<T>*>(m_currentEditContext.get());
                 if (ctx != nullptr) {
@@ -367,8 +380,13 @@ bool PropertiesInput(char const* label, T current, std::function<void(T)> const&
                 }
                 CommitEditContext();
             } else if (inputContext.Deactivated && !inputContext.Focused && m_currentEditContext && m_currentEditContext->GetID() == widgetId) {
-                // Cancelled (e.g. Escape): discard without committing.
-                m_currentEditContext.reset();
+                if (m_currentEditContext->HadDeactivatedAfterEdit()) {
+                    // A prior child was successfully edited — commit rather than discard.
+                    CommitEditContext();
+                } else {
+                    // Cancelled (e.g. Escape) with no prior edits: discard.
+                    m_currentEditContext.reset();
+                }
             }
         }
     }

--- a/src/editor/properties_elements.h
+++ b/src/editor/properties_elements.h
@@ -149,7 +149,7 @@ inline InputContext<moth_ui::FloatVec2> InputElement(char const* label, InputBuf
 }
 
 inline InputContext<moth_ui::Color> InputElement(char const* label, InputBuffer<moth_ui::Color> valueBuffer) {
-    bool changed = ImGui::ColorEdit4(label, valueBuffer.Buffer->data, 0);
+    bool changed = ImGui::ColorEdit4(label, valueBuffer.Buffer->data, ImGuiColorEditFlags_DisplayHex);
     bool focused = ImGui::IsItemFocused();
     return { changed, focused, valueBuffer };
 }

--- a/src/editor/properties_elements.h
+++ b/src/editor/properties_elements.h
@@ -68,12 +68,9 @@ private:
 };
 
 extern std::unique_ptr<PropertyEditContextBase> m_currentEditContext;
-extern ImGuiID m_editingID;
 
 ImGuiID GetCurrentEditFocusID();
 void CommitEditContext();
-void BeginEdits();
-void EndEdits();
 
 template <class SourceType>
 struct InputBuffer {
@@ -271,15 +268,54 @@ void OnInputFocus(char const* label, SourceType const& value, std::function<void
         CommitEditContext();
         m_currentEditContext = std::make_unique<PropertyEditContext<SourceType>>(id, value, commitAction);
     } else {
-        auto* context = static_cast<PropertyEditContext<SourceType>*>(m_currentEditContext.get());
-        context->UpdateValue(value);
+        auto* context = dynamic_cast<PropertyEditContext<SourceType>*>(m_currentEditContext.get());
+        if (context != nullptr) {
+            context->UpdateValue(value);
+        }
     }
-    m_editingID = id;
 }
 
 template <class T>
 bool PropertiesInput(char const* label, T current, std::function<void(T)> const& changeAction = {}, std::function<void(T, T)> const& commitAction = {}) {
     auto const inputContext = TypeInput(label, current);
+
+    if (commitAction) {
+        if constexpr (std::is_enum_v<T>) {
+            // Enum combos are instant-commit: selection completes in one frame.
+            if (inputContext.Changed) {
+                CommitEditContext();
+                commitAction(current, *inputContext.ValueBuffer.Buffer);
+            }
+        } else {
+            if (ImGui::IsItemActivated()) {
+                // Capture original value BEFORE changeAction has a chance to mutate the source.
+                CommitEditContext();
+                m_currentEditContext = std::make_unique<PropertyEditContext<T>>(ImGui::GetItemID(), current, commitAction);
+            }
+            if (inputContext.Changed && m_currentEditContext) {
+                auto* ctx = dynamic_cast<PropertyEditContext<T>*>(m_currentEditContext.get());
+                if (ctx != nullptr) {
+                    if constexpr (std::is_same_v<T, char const*>) {
+                        ctx->UpdateValue(inputContext.ValueBuffer.Buffer);
+                    } else {
+                        ctx->UpdateValue(*inputContext.ValueBuffer.Buffer);
+                    }
+                }
+            }
+            if (ImGui::IsItemDeactivatedAfterEdit() && m_currentEditContext && m_currentEditContext->GetID() == ImGui::GetItemID()) {
+                auto* ctx = dynamic_cast<PropertyEditContext<T>*>(m_currentEditContext.get());
+                if (ctx != nullptr) {
+                    if constexpr (std::is_same_v<T, char const*>) {
+                        ctx->UpdateValue(inputContext.ValueBuffer.Buffer);
+                    } else {
+                        ctx->UpdateValue(*inputContext.ValueBuffer.Buffer);
+                    }
+                }
+                CommitEditContext();
+            }
+        }
+    }
+
     if (changeAction && inputContext.Changed) {
         if constexpr (std::is_same_v<T, char const*>) {
             changeAction(inputContext.ValueBuffer.Buffer);
@@ -287,23 +323,7 @@ bool PropertiesInput(char const* label, T current, std::function<void(T)> const&
             changeAction(*inputContext.ValueBuffer.Buffer);
         }
     }
-    if (commitAction && inputContext.Focused) {
-        if constexpr (std::is_enum_v<T>) {
-            // Enum combos are instant-commit: selection completes in one frame so
-            // Focused and Changed arrive together. The focus-tracking path would
-            // capture the already-mutated value as originalValue and never see a
-            // delta. Instead, commit immediately using the pre-mutation value
-            // (current) and the newly selected value.
-            if (inputContext.Changed) {
-                CommitEditContext();
-                commitAction(current, *inputContext.ValueBuffer.Buffer);
-            }
-        } else if constexpr (std::is_same_v<T, char const*>) {
-            OnInputFocus<T>(label, inputContext.ValueBuffer.Buffer, commitAction);
-        } else {
-            OnInputFocus(label, *inputContext.ValueBuffer.Buffer, commitAction);
-        }
-    }
+
     return inputContext.Changed;
 }
 
@@ -327,13 +347,29 @@ inline bool PropertiesInput(char const* label, char const* text, int lines, std:
     auto valueBuffer = GetBufferForValue(text);
     // TODO: add ImGuiInputTextFlags_WordWrapping once imgui is upgraded to 1.91.0+
     bool const changed = ImGui::InputTextMultiline(label, valueBuffer.Buffer, valueBuffer.Size - 1, ImVec2{ 0, static_cast<float>(std::max(1, lines)) * ImGui::GetFontSize() });
-    bool const focused = ImGui::IsItemFocused();
+
+    if (commitAction) {
+        if (ImGui::IsItemActivated()) {
+            CommitEditContext();
+            m_currentEditContext = std::make_unique<PropertyEditContext<char const*>>(ImGui::GetItemID(), text, commitAction);
+        }
+        if (changed && m_currentEditContext) {
+            auto* ctx = dynamic_cast<PropertyEditContext<char const*>*>(m_currentEditContext.get());
+            if (ctx != nullptr) {
+                ctx->UpdateValue(valueBuffer.Buffer);
+            }
+        }
+        if (ImGui::IsItemDeactivatedAfterEdit() && m_currentEditContext && m_currentEditContext->GetID() == ImGui::GetItemID()) {
+            auto* ctx = dynamic_cast<PropertyEditContext<char const*>*>(m_currentEditContext.get());
+            if (ctx != nullptr) {
+                ctx->UpdateValue(valueBuffer.Buffer);
+            }
+            CommitEditContext();
+        }
+    }
 
     if (changeAction && changed) {
         changeAction(valueBuffer.Buffer);
-    }
-    if (commitAction && focused) {
-        OnInputFocus(label, static_cast<char const*>(valueBuffer.Buffer), commitAction);
     }
     return changed;
 }

--- a/src/editor/properties_elements.h
+++ b/src/editor/properties_elements.h
@@ -287,11 +287,25 @@ bool PropertiesInput(char const* label, T current, std::function<void(T)> const&
                 commitAction(current, *inputContext.ValueBuffer.Buffer);
             }
         } else {
-            if (ImGui::IsItemActivated()) {
-                // Capture original value BEFORE changeAction has a chance to mutate the source.
+            // Use the label's ID as a stable composite key so that multi-sub-widget
+            // inputs (IntRect, LayoutRect) are tracked as a single logical edit.
+            // For single-item inputs (InputText, InputFloat, etc.) GetID(label) equals
+            // GetItemID(), so the deactivation checks below remain correct for both.
+            auto const widgetId = ImGui::GetID(label);
+
+            if (ImGui::IsItemActivated() && ImGui::GetItemID() == widgetId) {
+                // Single-item widget: reliable activation signal — capture original
+                // BEFORE changeAction has a chance to mutate the source.
                 CommitEditContext();
-                m_currentEditContext = std::make_unique<PropertyEditContext<T>>(ImGui::GetItemID(), current, commitAction);
+                m_currentEditContext = std::make_unique<PropertyEditContext<T>>(widgetId, current, commitAction);
+            } else if (inputContext.Focused && GetCurrentEditFocusID() != widgetId) {
+                // Composite widget (IntRect, LayoutRect): IsItemActivated() only fires
+                // for the last sub-item, so use the accumulated focus state instead.
+                // current is still pre-mutation here because changeAction runs below.
+                CommitEditContext();
+                m_currentEditContext = std::make_unique<PropertyEditContext<T>>(widgetId, current, commitAction);
             }
+
             if (inputContext.Changed && m_currentEditContext) {
                 auto* ctx = dynamic_cast<PropertyEditContext<T>*>(m_currentEditContext.get());
                 if (ctx != nullptr) {
@@ -302,7 +316,14 @@ bool PropertiesInput(char const* label, T current, std::function<void(T)> const&
                     }
                 }
             }
-            if (ImGui::IsItemDeactivatedAfterEdit() && m_currentEditContext && m_currentEditContext->GetID() == ImGui::GetItemID()) {
+
+            // Deactivation checks compare against widgetId, which equals GetItemID()
+            // for single-item widgets so they commit/cancel on the correct frame.
+            // For composite widgets the last sub-item's ID won't match widgetId unless
+            // the user happened to leave via that last field, so composite commits are
+            // deferred to the next IsItemActivated() call (CommitEditContext()) or to
+            // the selection-change flush in EndPanel — both are reliable.
+            if (ImGui::IsItemDeactivatedAfterEdit() && m_currentEditContext && m_currentEditContext->GetID() == widgetId) {
                 auto* ctx = dynamic_cast<PropertyEditContext<T>*>(m_currentEditContext.get());
                 if (ctx != nullptr) {
                     if constexpr (std::is_same_v<T, char const*>) {
@@ -312,9 +333,8 @@ bool PropertiesInput(char const* label, T current, std::function<void(T)> const&
                     }
                 }
                 CommitEditContext();
-            } else if (ImGui::IsItemDeactivated() && m_currentEditContext && m_currentEditContext->GetID() == ImGui::GetItemID()) {
-                // Cancelled (e.g. Escape): discard context without committing so no
-                // spurious undo action is created from the partially-typed value.
+            } else if (ImGui::IsItemDeactivated() && m_currentEditContext && m_currentEditContext->GetID() == widgetId) {
+                // Cancelled (e.g. Escape): discard without committing.
                 m_currentEditContext.reset();
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Font picker accepts .otf and pre-fills the font name from the selected file.

* **Bug Fixes / UX**
  * Clip and event name edits now reliably commit when editing finishes.
  * Image file dialogs use a more consistent extension filter format.

* **Refactor / Chores**
  * Editing lifecycle simplified and global edit-tracking removed for more predictable input behavior.
  * CI simplified by removing an example build step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->