### PR TITLE
fix: animation panel, properties input, keyboard shortcuts, and color picker fixes

### DIFF
--- a/src/editor/bounds_widget.cpp
+++ b/src/editor/bounds_widget.cpp
@@ -79,7 +79,7 @@ moth_ui::FloatVec2 BoundsWidget::GetRotatedWorldPos(moth_ui::FloatVec2 const& wo
     auto const bounds = static_cast<moth_ui::FloatRect>(m_node->GetScreenRect());
     auto const dims = moth_ui::FloatVec2{ bounds.w(), bounds.h() };
     auto const entity = m_node->GetLayoutEntity();
-    auto const pivot = entity ? entity->m_pivot : moth_ui::FloatVec2{ 0.5f, 0.5f };
+    auto const pivot = m_node->GetPivot();
     auto const pivotWorld = bounds.topLeft + dims * pivot;
     float const rotation = m_node->GetRotation() * moth_ui::kDegToRad;
     float const c = std::cos(rotation);

--- a/src/editor/editor_layer.cpp
+++ b/src/editor/editor_layer.cpp
@@ -840,27 +840,27 @@ bool EditorLayer::OnKey(moth_ui::EventKey const& event) {
             }
         } break;
         case moth_ui::Key::Z:
-            if ((event.GetMods() & moth_ui::KeyMod_Ctrl) != 0) {
+            if (!wantKeyboard && (event.GetMods() & moth_ui::KeyMod_Ctrl) != 0) {
                 UndoEditAction();
             }
             return true;
         case moth_ui::Key::Y:
-            if ((event.GetMods() & moth_ui::KeyMod_Ctrl) != 0) {
+            if (!wantKeyboard && (event.GetMods() & moth_ui::KeyMod_Ctrl) != 0) {
                 RedoEditAction();
             }
             return true;
         case moth_ui::Key::C:
-            if ((event.GetMods() & moth_ui::KeyMod_Ctrl) != 0) {
+            if (!wantKeyboard && (event.GetMods() & moth_ui::KeyMod_Ctrl) != 0) {
                 CopyEntity();
             }
             return true;
         case moth_ui::Key::X:
-            if ((event.GetMods() & moth_ui::KeyMod_Ctrl) != 0) {
+            if (!wantKeyboard && (event.GetMods() & moth_ui::KeyMod_Ctrl) != 0) {
                 CutEntity();
             }
             return true;
         case moth_ui::Key::V:
-            if ((event.GetMods() & moth_ui::KeyMod_Ctrl) != 0) {
+            if (!wantKeyboard && (event.GetMods() & moth_ui::KeyMod_Ctrl) != 0) {
                 PasteEntity();
             }
             return true;

--- a/src/editor/panels/editor_panel_animation.cpp
+++ b/src/editor/panels/editor_panel_animation.cpp
@@ -618,6 +618,9 @@ bool EditorPanelAnimation::DrawClipPopup() {
         if (stillExists && m_pendingClipEdit->HasChanged()) {
             auto action = std::make_unique<ModifyClipAction>(groupEntity, *m_pendingClipEdit->reference, m_pendingClipEdit->mutableValue);
             m_editorLayer.PerformEditAction(std::move(action));
+            if (auto* selCtx = GetSelectedClipContext(m_pendingClipEdit->reference)) {
+                selCtx->mutableValue = m_pendingClipEdit->mutableValue;
+            }
         }
         m_pendingClipEdit.reset();
     }
@@ -787,6 +790,9 @@ bool EditorPanelAnimation::DrawEventPopup() {
         if (stillExists && m_pendingEventEdit->HasChanged()) {
             auto action = std::make_unique<ModifyEventAction>(groupEntity, *m_pendingEventEdit->reference, m_pendingEventEdit->mutableValue);
             m_editorLayer.PerformEditAction(std::move(action));
+            if (auto* selCtx = GetSelectedEventContext(m_pendingEventEdit->reference)) {
+                selCtx->mutableValue = m_pendingEventEdit->mutableValue;
+            }
         }
         m_pendingEventEdit.reset();
     }

--- a/src/editor/panels/editor_panel_canvas.cpp
+++ b/src/editor/panels/editor_panel_canvas.cpp
@@ -36,8 +36,7 @@ namespace {
     moth_ui::FloatVec2 GetNodePivotWorld(moth_ui::Node const& node) {
         auto const bounds = static_cast<moth_ui::FloatRect>(node.GetScreenRect());
         auto const dims = moth_ui::FloatVec2{ bounds.w(), bounds.h() };
-        auto const entity = node.GetLayoutEntity();
-        auto const pivot = entity ? entity->m_pivot : moth_ui::FloatVec2{ 0.5f, 0.5f };
+        auto const pivot = node.GetPivot();
         return bounds.topLeft + dims * pivot;
     }
 

--- a/src/editor/panels/editor_panel_properties.cpp
+++ b/src/editor/panels/editor_panel_properties.cpp
@@ -221,6 +221,24 @@ void EditorPanelProperties::DrawBoundsTools(std::shared_ptr<moth_ui::Node> node)
     }
 
 
+    // Copy / Paste bounds
+    if (ImGui::Button("Copy Bounds")) {
+        m_boundsClipboard = node->GetLayoutRect();
+    }
+    ImGui::SameLine();
+    if (!m_boundsClipboard.has_value()) {
+        ImGui::BeginDisabled();
+    }
+    if (ImGui::Button("Paste Bounds")) {
+        m_editorLayer.BeginEditBounds(node);
+        node->GetLayoutRect() = *m_boundsClipboard;
+        node->RecalculateBounds();
+        m_editorLayer.EndEditBounds();
+    }
+    if (!m_boundsClipboard.has_value()) {
+        ImGui::EndDisabled();
+    }
+
     auto* parent = node->GetParent();
     if (parent == nullptr) {
         ImGui::TextDisabled("(root node has no parent)");

--- a/src/editor/panels/editor_panel_properties.cpp
+++ b/src/editor/panels/editor_panel_properties.cpp
@@ -164,7 +164,10 @@ void EditorPanelProperties::DrawCommonProperties(std::shared_ptr<moth_ui::Node> 
     ImGui::Unindent();
 
     PropertiesInput<moth_ui::FloatVec2>(
-        "Pivot", entity->m_pivot, {},
+        "Pivot", entity->m_pivot,
+        [node](moth_ui::FloatVec2 changedValue) {
+            node->SetPivot(changedValue);
+        },
         [this, node, entity](moth_ui::FloatVec2 oldValue, moth_ui::FloatVec2 newValue) {
             auto action = MakeChangeValueAction(entity->m_pivot, oldValue, newValue, [node]() {
                 node->ReloadEntity();

--- a/src/editor/panels/editor_panel_properties.cpp
+++ b/src/editor/panels/editor_panel_properties.cpp
@@ -198,11 +198,10 @@ void EditorPanelProperties::DrawCommonProperties(std::shared_ptr<moth_ui::Node> 
 
         // Commit when: the inline item was edited directly (hex field) and lost focus,
         // OR a colour edit is pending and no popup is currently open (picker dismissed).
-        ImGui::PushID("Color");
-        bool const colorPickerOpen = ImGui::IsPopupOpen("##Picker");
-        ImGui::PopID();
-        bool const allPopupsClosed = !colorPickerOpen;
-        if (deactivatedAfterEdit || (m_editorLayer.HasPendingColorEdit() && allPopupsClosed)) {
+        // Use AnyPopupId because ColorEdit4 internally pushes extra IDs (color button
+        // etc.) so a narrowly scoped IsPopupOpen("##Picker") won't match.
+        bool const anyPopupOpen = ImGui::IsPopupOpen(nullptr, ImGuiPopupFlags_AnyPopupId);
+        if (deactivatedAfterEdit || (m_editorLayer.HasPendingColorEdit() && !anyPopupOpen)) {
             m_editorLayer.EndEditColor();
         }
     }

--- a/src/editor/panels/editor_panel_properties.h
+++ b/src/editor/panels/editor_panel_properties.h
@@ -2,6 +2,7 @@
 
 #include "editor_panel.h"
 #include "moth_ui/context.h"
+#include "moth_ui/layout/layout_rect.h"
 
 class EditorPanelProperties : public EditorPanel {
 public:
@@ -17,6 +18,7 @@ private:
 
     std::shared_ptr<moth_ui::Node> m_currentSelection = nullptr;
     std::shared_ptr<moth_ui::Node> m_lastSelection = nullptr;
+    std::optional<moth_ui::LayoutRect> m_boundsClipboard;
 
     void DrawNodeProperties(std::shared_ptr<moth_ui::Node> node, bool recurseChildren = true);
     void DrawCommonProperties(std::shared_ptr<moth_ui::Node> node);

--- a/src/editor/pivot_bounds_handle.cpp
+++ b/src/editor/pivot_bounds_handle.cpp
@@ -33,8 +33,7 @@ void PivotBoundsHandle::Draw() {
     auto const& screenRect = m_target->GetScreenRect();
     auto const bounds = static_cast<moth_ui::FloatRect>(screenRect);
     auto const dims = moth_ui::FloatVec2{ bounds.w(), bounds.h() };
-    auto const entity = m_target->GetLayoutEntity();
-    auto const pivot = entity ? entity->m_pivot : moth_ui::FloatVec2{ 0.5f, 0.5f };
+    auto const pivot = m_target->GetPivot();
 
     m_position = bounds.topLeft + dims * pivot;
 
@@ -75,7 +74,7 @@ void PivotBoundsHandle::UpdatePosition(moth_ui::IntVec2 const& position) {
     float const s = std::sin(rotation);
 
     // Current pivot in world space (the rotation centre — unchanged by rotation).
-    auto const pivotLocalOld = entity->m_pivot * dims;
+    auto const pivotLocalOld = m_target->GetPivot() * dims;
     auto const pivotWorldOld = bounds.topLeft + pivotLocalOld;
 
     // Back-rotate the mouse-from-pivot vector into the node's local (unrotated)

--- a/src/editor/properties_elements.h
+++ b/src/editor/properties_elements.h
@@ -245,28 +245,28 @@ inline InputContext<moth_ui::LayoutRect> InputElement(char const* label, InputBu
 
             ImGui::TableNextColumn();
             ImGui::SetNextItemWidth(-FLT_MIN);
-            changed |= ImGui::InputFloat("##l", &rect.topLeft.x, 0, 0, "%.2f");
+            changed |= ImGui::InputFloat("##l", &rect.topLeft.x, 0, 0, "%.4f");
             focused |= ImGui::IsItemFocused();
             deactivatedAfterEdit |= ImGui::IsItemDeactivatedAfterEdit();
             deactivated |= ImGui::IsItemDeactivated();
 
             ImGui::TableNextColumn();
             ImGui::SetNextItemWidth(-FLT_MIN);
-            changed |= ImGui::InputFloat("##t", &rect.topLeft.y, 0, 0, "%.2f");
+            changed |= ImGui::InputFloat("##t", &rect.topLeft.y, 0, 0, "%.4f");
             focused |= ImGui::IsItemFocused();
             deactivatedAfterEdit |= ImGui::IsItemDeactivatedAfterEdit();
             deactivated |= ImGui::IsItemDeactivated();
 
             ImGui::TableNextColumn();
             ImGui::SetNextItemWidth(-FLT_MIN);
-            changed |= ImGui::InputFloat("##r", &rect.bottomRight.x, 0, 0, "%.2f");
+            changed |= ImGui::InputFloat("##r", &rect.bottomRight.x, 0, 0, "%.4f");
             focused |= ImGui::IsItemFocused();
             deactivatedAfterEdit |= ImGui::IsItemDeactivatedAfterEdit();
             deactivated |= ImGui::IsItemDeactivated();
 
             ImGui::TableNextColumn();
             ImGui::SetNextItemWidth(-FLT_MIN);
-            changed |= ImGui::InputFloat("##b", &rect.bottomRight.y, 0, 0, "%.2f");
+            changed |= ImGui::InputFloat("##b", &rect.bottomRight.y, 0, 0, "%.4f");
             focused |= ImGui::IsItemFocused();
             deactivatedAfterEdit |= ImGui::IsItemDeactivatedAfterEdit();
             deactivated |= ImGui::IsItemDeactivated();

--- a/src/editor/properties_elements.h
+++ b/src/editor/properties_elements.h
@@ -31,6 +31,10 @@ public:
         m_pendingValue = value;
     }
 
+    T const& GetPendingValue() const {
+        return m_pendingValue;
+    }
+
     void Commit() override {
         if (m_originalValue != m_pendingValue) {
             m_commitAction(m_originalValue, m_pendingValue);
@@ -56,6 +60,10 @@ public:
 
     void UpdateValue(char const* const& value) {
         m_pendingValue = value;
+    }
+
+    std::string const& GetPendingValue() const {
+        return m_pendingValue;
     }
 
     void Commit() override {
@@ -384,7 +392,26 @@ void OnInputFocus(char const* label, SourceType const& value, std::function<void
 
 template <class T>
 bool PropertiesInput(char const* label, T current, std::function<void(T)> const& changeAction = {}, std::function<void(T, T)> const& commitAction = {}) {
-    auto const inputContext = TypeInput(label, current);
+    // When an edit is already in progress, feed the pending value back
+    // as the display value so that composite widgets (FloatVec2, IntVec2,
+    // LayoutRect) do not lose previously-edited fields.  The InputElement
+    // buffer is rebuilt from current each frame, but ImGui only preserves
+    // the active sub-item's value across frames; inactive sub-items revert
+    // to whatever they receive.  Using the pending value ensures the
+    // buffer reflects all accumulated edits, not just the most recent one.
+    auto const widgetId = ImGui::GetID(label);
+    T displayValue = current;
+    if (m_currentEditContext && m_currentEditContext->GetID() == widgetId) {
+        auto* ctx = dynamic_cast<PropertyEditContext<T>*>(m_currentEditContext.get());
+        if (ctx != nullptr) {
+            if constexpr (std::is_same_v<T, char const*>) {
+                displayValue = ctx->GetPendingValue().c_str();
+            } else {
+                displayValue = ctx->GetPendingValue();
+            }
+        }
+    }
+    auto const inputContext = TypeInput(label, displayValue);
 
     if (commitAction) {
         if constexpr (std::is_enum_v<T>) {
@@ -394,12 +421,6 @@ bool PropertiesInput(char const* label, T current, std::function<void(T)> const&
                 commitAction(current, *inputContext.ValueBuffer.Buffer);
             }
         } else {
-            // Use the label's ID as a stable composite key so that multi-sub-widget
-            // inputs (IntRect, LayoutRect) are tracked as a single logical edit.
-            // For single-item inputs (InputText, InputFloat, etc.) GetID(label) equals
-            // GetItemID(), so the deactivation checks below remain correct for both.
-            auto const widgetId = ImGui::GetID(label);
-
             if (ImGui::IsItemActivated() && ImGui::GetItemID() == widgetId) {
                 // Single-item widget: reliable activation signal — capture original
                 // BEFORE changeAction has a chance to mutate the source.


### PR DESCRIPTION
## Summary
- Fix clip/event name reset on drag/drop after popup rename (stale mutableValue snapshot)
- Fix composite PropertiesInput widgets losing prior sub-field edits when tabbing
- Add Copy/Paste Bounds buttons to the properties panel bounds tools
- Fix global Ctrl+C/V/X/Z/Y shortcuts firing while ImGui text inputs have focus
- Fix color picker creating per-frame undo actions (popup scoping mismatch)

## Test plan
- [ ] Rename clip via right-click Edit, drag it — name persists
- [ ] Edit pivot x, tab to y, edit y — both x and y changes persist
- [ ] Copy/paste bounds between nodes via buttons in properties panel
- [ ] Ctrl+C/V in properties text inputs — copies/pastes text, not nodes
- [ ] Drag in color picker, dismiss, undo — reverts to pre-picker color in one step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy and paste controls for bounds in the bounds tools section.

* **Bug Fixes**
  * Keyboard shortcuts now properly respect UI input focus during editing.
  * Selection edits now properly synchronize with committed values.
  * Property input fields correctly display pending edits during editing sessions.
  * Improved color picker popup detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->