### PR TITLE
refactor: decouple animation panel view and state via AnimationIntent

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - os: windows
-            runs_on: windows-latest
+            runs_on: windows-2022
             configure_preset: conan-default
           - os: linux
             runs_on: ubuntu-latest

--- a/.github/workflows/upload-release.yml
+++ b/.github/workflows/upload-release.yml
@@ -69,7 +69,7 @@ jobs:
       matrix:
         include:
           - os: windows
-            runs_on: windows-latest
+            runs_on: windows-2022
           - os: linux
             runs_on: ubuntu-latest
 
@@ -108,12 +108,12 @@ jobs:
         include:
           - os: windows
             build_type: Release
-            runs_on: windows-latest
+            runs_on: windows-2022
             configure_preset: conan-default
             build_preset: conan-release
           - os: windows
             build_type: Debug
-            runs_on: windows-latest
+            runs_on: windows-2022
             configure_preset: conan-default
             build_preset: conan-debug
           - os: linux

--- a/conanfile.py
+++ b/conanfile.py
@@ -19,8 +19,8 @@ class MothUIEditor(ConanFile):
             self.version = load(self, "version.txt").strip()
 
     def requirements(self):
-        self.requires("moth_ui/1.0.0-rc.1")
-        self.requires("moth_graphics/1.0.0-rc.1")
+        self.requires("moth_ui/1.0.0")
+        self.requires("moth_graphics/1.0.0")
         self.requires("moth_packer/1.0.0-rc.1")
 
     def system_requirements(self):

--- a/src/editor/editor_layer.cpp
+++ b/src/editor/editor_layer.cpp
@@ -48,10 +48,11 @@
 
 EditorLayer::~EditorLayer() = default;
 
-EditorLayer::EditorLayer(moth_ui::Context& context, moth_graphics::graphics::IGraphics& graphics, EditorApplication* app)
+EditorLayer::EditorLayer(moth_ui::Context& context, moth_graphics::graphics::IGraphics& graphics, moth_graphics::graphics::AssetContext& assetContext, EditorApplication* app)
     : m_app(app)
     , m_context(context)
-    , m_graphics(graphics) {
+    , m_graphics(graphics)
+    , m_assetContext(assetContext) {
 #if defined(_WIN32)
     m_crashRecoveryPath = std::filesystem::temp_directory_path() / fmt::format("moth_editor_recovery_{}.moth", _getpid());
 #else

--- a/src/editor/editor_layer.h
+++ b/src/editor/editor_layer.h
@@ -16,6 +16,7 @@ class TexturePacker;
 #include "moth_ui/events/event_mouse.h"
 #include "moth_ui/events/event_key.h"
 
+#include "moth_graphics/graphics/asset_context.h"
 #include "moth_graphics/graphics/igraphics.h"
 #include "moth_graphics/events/event_window.h"
 
@@ -28,10 +29,11 @@ class EditorApplication;
 
 class EditorLayer : public moth_ui::Layer {
 public:
-    EditorLayer(moth_ui::Context& context, moth_graphics::graphics::IGraphics& graphics, EditorApplication* app);
+    EditorLayer(moth_ui::Context& context, moth_graphics::graphics::IGraphics& graphics, moth_graphics::graphics::AssetContext& assetContext, EditorApplication* app);
     ~EditorLayer() override;
 
     moth_graphics::graphics::IGraphics& GetGraphics() const { return m_graphics; }
+    moth_graphics::graphics::AssetContext& GetAssetContext() const { return m_assetContext; }
 
     bool OnEvent(moth_ui::Event const& event) override;
 
@@ -141,6 +143,7 @@ private:
     EditorApplication* m_app = nullptr;
     moth_ui::Context& m_context;
     moth_graphics::graphics::IGraphics& m_graphics;
+    moth_graphics::graphics::AssetContext& m_assetContext;
 
     EditorConfig m_config;
 

--- a/src/editor/imgui_ext.cpp
+++ b/src/editor/imgui_ext.cpp
@@ -59,9 +59,9 @@ namespace imgui_ext {
         ImGui::Text("%s", label);
     }
 
-    void Image(moth_graphics::graphics::IImage const* image, int width, int height) {
-        if (image != nullptr) {
-            image->ImGui({ width, height });
+    void Image(moth_graphics::graphics::Image const& image, int width, int height) {
+        if (image) {
+            image.DrawImGui({ width, height });
         }
     }
 
@@ -69,7 +69,7 @@ namespace imgui_ext {
         if (image != nullptr) {
             auto const* mothImage = dynamic_cast<moth_graphics::graphics::MothImage const*>(image);
             if (mothImage != nullptr) {
-                mothImage->GetImage()->ImGui({ width, height });
+                mothImage->GetImage().DrawImGui({ width, height });
             }
         }
     }

--- a/src/editor/imgui_ext.h
+++ b/src/editor/imgui_ext.h
@@ -13,6 +13,6 @@ namespace imgui_ext {
     void InputIntVec2(char const* label, moth_ui::IntVec2* vec);
     void InputFloatVec2(char const* label, moth_ui::FloatVec2* vec);
 
-    void Image(moth_graphics::graphics::IImage const* image, int width, int height);
+    void Image(moth_graphics::graphics::Image const& image, int width, int height);
     void Image(moth_ui::IImage const* image, int width, int height);
 }

--- a/src/editor/imgui_ext.h
+++ b/src/editor/imgui_ext.h
@@ -2,7 +2,7 @@
 
 #include "moth_ui/moth_ui_fwd.h"
 #include "moth_ui/utils/vector.h"
-#include "moth_graphics/graphics/iimage.h"
+#include "moth_graphics/graphics/image.h"
 
 #include <string>
 

--- a/src/editor/panels/animation_intent.h
+++ b/src/editor/panels/animation_intent.h
@@ -2,8 +2,15 @@
 
 #include "moth_ui/animation/animation_clip.h"
 #include "moth_ui/animation/animation_marker.h"
+#include "moth_ui/animation/animation_track.h"
 
+#include <memory>
 #include <variant>
+
+namespace moth_ui {
+    class Node;
+    class LayoutEntity;
+}
 
 namespace anim_intent {
     // Selects a clip. If additive (Ctrl held), preserves existing selection;
@@ -51,6 +58,31 @@ namespace anim_intent {
 
     // Commits an in-progress event edit as a ModifyEventAction.
     struct CommitEventEdit { moth_ui::AnimationMarker* reference; moth_ui::AnimationMarker newValue; };
+
+    // Click on a child label in the track header column: toggles entity
+    // selection (and clears prior selection when !additive). The label-drag
+    // source bookkeeping (m_labelDragSourceIdx) stays direct view state.
+    struct ClickChildLabel { std::shared_ptr<moth_ui::Node> child; bool additive; };
+
+    // Select a continuous-track keyframe. The expanded flag selects between
+    // ClearSelections (expanded) and FilterKeyframeSelections (collapsed) when
+    // the keyframe wasn't already selected and !additive.
+    struct ClickKeyframe { std::shared_ptr<moth_ui::LayoutEntity> entity; moth_ui::AnimationTrack::Target target; int frame; bool additive; bool expanded; };
+
+    // Same as ClickKeyframe but for discrete-track keyframes.
+    struct ClickDiscreteKeyframe { std::shared_ptr<moth_ui::LayoutEntity> entity; moth_ui::AnimationTrack::Target target; int frame; bool additive; bool expanded; };
+
+    // Start dragging the current keyframe selection. altDrag seeds the
+    // duplicate-on-drag flag with the alt-modifier state at gesture start.
+    struct BeginKeyframeDrag { float mouseX; bool altDrag; };
+
+    // Open the keyframe right-click context menu. isDiscrete picks the discrete
+    // vs continuous branch inside the popup; target == Unknown means the click
+    // hit a collapsed main row.
+    struct OpenKeyframePopup { int childIndex; moth_ui::AnimationTrack::Target target; bool isDiscrete; int atFrame; };
+
+    // Commit a child-label drag-to-reorder gesture as a ChangeIndexAction.
+    struct CommitLabelReorder { std::shared_ptr<moth_ui::Node> node; int sourceIdx; int newIndex; };
 }
 
 using AnimationIntent = std::variant<
@@ -65,5 +97,11 @@ using AnimationIntent = std::variant<
     anim_intent::AddEvent,
     anim_intent::DeleteSelections,
     anim_intent::CommitClipEdit,
-    anim_intent::CommitEventEdit
+    anim_intent::CommitEventEdit,
+    anim_intent::ClickChildLabel,
+    anim_intent::ClickKeyframe,
+    anim_intent::ClickDiscreteKeyframe,
+    anim_intent::BeginKeyframeDrag,
+    anim_intent::OpenKeyframePopup,
+    anim_intent::CommitLabelReorder
 >;

--- a/src/editor/panels/animation_intent.h
+++ b/src/editor/panels/animation_intent.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "moth_ui/animation/animation_clip.h"
+#include "moth_ui/animation/animation_marker.h"
 
 #include <variant>
 
@@ -10,6 +11,11 @@ namespace anim_intent {
     // selected. Single intent so Apply owns the click-policy in one place.
     struct ClickClip { moth_ui::AnimationClip* clip; bool additive; };
 
+    // Selects an event marker. If additive (Ctrl held), preserves existing
+    // selection; otherwise clears prior selection unconditionally before
+    // selecting (note: the policy differs from ClickClip).
+    struct ClickEvent { moth_ui::AnimationMarker* event; bool additive; };
+
     // Marks the current click as handled so the panel-level "unhandled click in
     // track area" path doesn't fall through to starting a box-select.
     struct ConsumeClick {};
@@ -18,13 +24,23 @@ namespace anim_intent {
     // (Left | Right | Center).
     struct BeginClipDrag { int handle; float mouseX; };
 
+    // Start dragging an event marker. Events are single-frame so there is no
+    // resize handle.
+    struct BeginEventDrag { float mouseX; };
+
     // Open the clip right-click context menu, anchored at the given frame.
     struct OpenClipPopup { int atFrame; };
+
+    // Open the event right-click context menu, anchored at the given frame.
+    struct OpenEventPopup { int atFrame; };
 }
 
 using AnimationIntent = std::variant<
     anim_intent::ClickClip,
+    anim_intent::ClickEvent,
     anim_intent::ConsumeClick,
     anim_intent::BeginClipDrag,
-    anim_intent::OpenClipPopup
+    anim_intent::BeginEventDrag,
+    anim_intent::OpenClipPopup,
+    anim_intent::OpenEventPopup
 >;

--- a/src/editor/panels/animation_intent.h
+++ b/src/editor/panels/animation_intent.h
@@ -33,6 +33,24 @@ namespace anim_intent {
 
     // Open the event right-click context menu, anchored at the given frame.
     struct OpenEventPopup { int atFrame; };
+
+    // Adds a new clip starting at the given frame. Apply fills in the default
+    // name/length so the intent stays a pure user-gesture record.
+    struct AddClip { int atFrame; };
+
+    // Adds a new empty-named event marker at the given frame.
+    struct AddEvent { int atFrame; };
+
+    // Deletes whatever is currently in the selection set (clips, events, or
+    // keyframes — routed through EditorPanelAnimation::DeleteSelections).
+    struct DeleteSelections {};
+
+    // Commits an in-progress clip edit (from the popup's Edit menu) as a
+    // ModifyClipAction. `reference` must still exist in m_clips when applied.
+    struct CommitClipEdit { moth_ui::AnimationClip* reference; moth_ui::AnimationClip newValue; };
+
+    // Commits an in-progress event edit as a ModifyEventAction.
+    struct CommitEventEdit { moth_ui::AnimationMarker* reference; moth_ui::AnimationMarker newValue; };
 }
 
 using AnimationIntent = std::variant<
@@ -42,5 +60,10 @@ using AnimationIntent = std::variant<
     anim_intent::BeginClipDrag,
     anim_intent::BeginEventDrag,
     anim_intent::OpenClipPopup,
-    anim_intent::OpenEventPopup
+    anim_intent::OpenEventPopup,
+    anim_intent::AddClip,
+    anim_intent::AddEvent,
+    anim_intent::DeleteSelections,
+    anim_intent::CommitClipEdit,
+    anim_intent::CommitEventEdit
 >;

--- a/src/editor/panels/animation_intent.h
+++ b/src/editor/panels/animation_intent.h
@@ -3,8 +3,10 @@
 #include "moth_ui/animation/animation_clip.h"
 #include "moth_ui/animation/animation_marker.h"
 #include "moth_ui/animation/animation_track.h"
+#include "moth_ui/utils/interp.h"
 
 #include <memory>
+#include <string>
 #include <variant>
 
 namespace moth_ui {
@@ -83,6 +85,23 @@ namespace anim_intent {
 
     // Commit a child-label drag-to-reorder gesture as a ChangeIndexAction.
     struct CommitLabelReorder { std::shared_ptr<moth_ui::Node> node; int sourceIdx; int newIndex; };
+
+    // Add a new discrete keyframe at the popup's frame. Apply re-reads the
+    // track to seed the value from whatever was active there.
+    struct AddDiscreteKeyframe { std::shared_ptr<moth_ui::LayoutEntity> entity; moth_ui::AnimationTrack::Target target; int frame; };
+
+    // Add one or more continuous keyframes. target == Unknown means the click
+    // was on a collapsed main row — Apply expands it to every continuous
+    // target without an existing keyframe at this frame.
+    struct AddContinuousKeyframes { std::shared_ptr<moth_ui::LayoutEntity> entity; moth_ui::AnimationTrack::Target target; int frame; };
+
+    // Replace a discrete keyframe's value (uses AddDiscreteKeyframeAction —
+    // the action overwrites when a keyframe already exists at the frame).
+    struct SetDiscreteKeyframeValue { std::shared_ptr<moth_ui::LayoutEntity> entity; moth_ui::AnimationTrack::Target target; int frame; std::string value; };
+
+    // Change the interpType of every continuous keyframe in the current
+    // selection set, as one composite undoable action.
+    struct CommitInterpChange { moth_ui::InterpType interpType; };
 }
 
 using AnimationIntent = std::variant<
@@ -103,5 +122,9 @@ using AnimationIntent = std::variant<
     anim_intent::ClickDiscreteKeyframe,
     anim_intent::BeginKeyframeDrag,
     anim_intent::OpenKeyframePopup,
-    anim_intent::CommitLabelReorder
+    anim_intent::CommitLabelReorder,
+    anim_intent::AddDiscreteKeyframe,
+    anim_intent::AddContinuousKeyframes,
+    anim_intent::SetDiscreteKeyframeValue,
+    anim_intent::CommitInterpChange
 >;

--- a/src/editor/panels/animation_intent.h
+++ b/src/editor/panels/animation_intent.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "moth_ui/animation/animation_clip.h"
+
+#include <variant>
+
+namespace anim_intent {
+    // Selects a clip. If additive (Ctrl held), preserves existing selection;
+    // otherwise clears prior selection first unless the clip was already
+    // selected. Single intent so Apply owns the click-policy in one place.
+    struct ClickClip { moth_ui::AnimationClip* clip; bool additive; };
+
+    // Marks the current click as handled so the panel-level "unhandled click in
+    // track area" path doesn't fall through to starting a box-select.
+    struct ConsumeClick {};
+
+    // Start dragging a clip. `handle` is a ClipDragHandle bitmask
+    // (Left | Right | Center).
+    struct BeginClipDrag { int handle; float mouseX; };
+
+    // Open the clip right-click context menu, anchored at the given frame.
+    struct OpenClipPopup { int atFrame; };
+}
+
+using AnimationIntent = std::variant<
+    anim_intent::ClickClip,
+    anim_intent::ConsumeClick,
+    anim_intent::BeginClipDrag,
+    anim_intent::OpenClipPopup
+>;

--- a/src/editor/panels/editor_panel_animation.cpp
+++ b/src/editor/panels/editor_panel_animation.cpp
@@ -575,7 +575,7 @@ void EditorPanelAnimation::DrawFrameNumberRibbon() {
 // Clip popup (right-click context menu on clips row)
 // ---------------------------------------------------------------------------
 
-bool EditorPanelAnimation::DrawClipPopup() {
+bool EditorPanelAnimation::DrawClipPopup(std::vector<AnimationIntent>& intents) {
     if (ImGui::BeginPopup(ClipPopupName)) {
         auto layout = std::static_pointer_cast<LayoutEntityGroup>(m_group->GetLayoutEntity());
         auto const it = ranges::find_if(layout->m_clips, [&](auto const& clip) {
@@ -588,16 +588,10 @@ bool EditorPanelAnimation::DrawClipPopup() {
         }
 
         if (m_selections.empty() && ImGui::MenuItem("Add")) {
-            auto entity = std::static_pointer_cast<LayoutEntityGroup>(m_group->GetLayoutEntity());
-            auto newClip = moth_ui::AnimationClip();
-            newClip.name = "New Clip";
-            newClip.startFrame = m_clickedFrame;
-            newClip.endFrame = newClip.startFrame + 10;
-            auto action = std::make_unique<AddClipAction>(entity, newClip);
-            m_editorLayer.PerformEditAction(std::move(action));
+            intents.emplace_back(anim_intent::AddClip{ m_clickedFrame });
         }
         if (!m_selections.empty() && ImGui::MenuItem("Delete")) {
-            DeleteSelections();
+            intents.emplace_back(anim_intent::DeleteSelections{});
         }
 
         if (clipContext != nullptr && ImGui::BeginMenu("Edit")) {
@@ -641,17 +635,15 @@ bool EditorPanelAnimation::DrawClipPopup() {
         return true;
     }
 
-    // Popup just closed — commit any pending edits if the clip still exists and changed.
+    // Popup just closed — emit a commit intent if the clip still exists and the
+    // pending edit actually changed. m_pendingClipEdit is view state owned by
+    // this function, so we reset it here regardless of commit eligibility.
     if (m_pendingClipEdit.has_value()) {
         auto groupEntity = std::static_pointer_cast<moth_ui::LayoutEntityGroup>(m_group->GetLayoutEntity());
         auto const& clips = groupEntity->m_clips;
         bool const stillExists = std::any_of(clips.begin(), clips.end(), [&](auto const& c) { return c.get() == m_pendingClipEdit->reference; });
         if (stillExists && m_pendingClipEdit->HasChanged()) {
-            auto action = std::make_unique<ModifyClipAction>(groupEntity, *m_pendingClipEdit->reference, m_pendingClipEdit->mutableValue);
-            m_editorLayer.PerformEditAction(std::move(action));
-            if (auto* selCtx = GetSelectedClipContext(m_pendingClipEdit->reference)) {
-                selCtx->mutableValue = m_pendingClipEdit->mutableValue;
-            }
+            intents.emplace_back(anim_intent::CommitClipEdit{ m_pendingClipEdit->reference, m_pendingClipEdit->mutableValue });
         }
         m_pendingClipEdit.reset();
     }
@@ -668,7 +660,7 @@ void EditorPanelAnimation::DrawClipRow(std::vector<AnimationIntent>& intents) {
 
     ImGuiIO const& io = ImGui::GetIO();
 
-    bool const popupShown = DrawClipPopup();
+    bool const popupShown = DrawClipPopup(intents);
 
     // Cancel pending selection clear if we click in a popup.
     if (ImGui::IsMouseClicked(ImGuiMouseButton_Left) && popupShown) {
@@ -773,6 +765,32 @@ void EditorPanelAnimation::Apply(AnimationIntent const& intent) {
     } else if (auto const* p = std::get_if<anim_intent::OpenEventPopup>(&intent)) {
         m_clickedFrame = p->atFrame;
         ImGui::OpenPopup(EventPopupName);
+    } else if (auto const* a = std::get_if<anim_intent::AddClip>(&intent)) {
+        auto entity = std::static_pointer_cast<LayoutEntityGroup>(m_group->GetLayoutEntity());
+        AnimationClip newClip;
+        newClip.name = "New Clip";
+        newClip.startFrame = a->atFrame;
+        newClip.endFrame = newClip.startFrame + 10;
+        m_editorLayer.PerformEditAction(std::make_unique<AddClipAction>(entity, newClip));
+    } else if (auto const* a = std::get_if<anim_intent::AddEvent>(&intent)) {
+        auto entity = std::static_pointer_cast<LayoutEntityGroup>(m_group->GetLayoutEntity());
+        std::unique_ptr<IEditorAction> action = std::make_unique<AddEventAction>(entity, a->atFrame, "");
+        action->Do();
+        m_editorLayer.AddEditAction(std::move(action));
+    } else if (std::holds_alternative<anim_intent::DeleteSelections>(intent)) {
+        DeleteSelections();
+    } else if (auto const* c = std::get_if<anim_intent::CommitClipEdit>(&intent)) {
+        auto entity = std::static_pointer_cast<LayoutEntityGroup>(m_group->GetLayoutEntity());
+        m_editorLayer.PerformEditAction(std::make_unique<ModifyClipAction>(entity, *c->reference, c->newValue));
+        if (auto* selCtx = GetSelectedClipContext(c->reference)) {
+            selCtx->mutableValue = c->newValue;
+        }
+    } else if (auto const* e = std::get_if<anim_intent::CommitEventEdit>(&intent)) {
+        auto entity = std::static_pointer_cast<LayoutEntityGroup>(m_group->GetLayoutEntity());
+        m_editorLayer.PerformEditAction(std::make_unique<ModifyEventAction>(entity, *e->reference, e->newValue));
+        if (auto* selCtx = GetSelectedEventContext(e->reference)) {
+            selCtx->mutableValue = e->newValue;
+        }
     }
 }
 
@@ -780,7 +798,7 @@ void EditorPanelAnimation::Apply(AnimationIntent const& intent) {
 // Event popup (right-click context menu on events row)
 // ---------------------------------------------------------------------------
 
-bool EditorPanelAnimation::DrawEventPopup() {
+bool EditorPanelAnimation::DrawEventPopup(std::vector<AnimationIntent>& intents) {
     if (ImGui::BeginPopup(EventPopupName)) {
         auto layout = std::static_pointer_cast<LayoutEntityGroup>(m_group->GetLayoutEntity());
         auto const it = ranges::find_if(layout->m_events, [&](auto const& event) {
@@ -793,14 +811,11 @@ bool EditorPanelAnimation::DrawEventPopup() {
         }
 
         if (eventContext == nullptr && ImGui::MenuItem("Add")) {
-            auto groupEntity = std::static_pointer_cast<moth_ui::LayoutEntityGroup>(m_group->GetLayoutEntity());
-            std::unique_ptr<IEditorAction> action = std::make_unique<AddEventAction>(groupEntity, m_clickedFrame, "");
-            action->Do();
-            m_editorLayer.AddEditAction(std::move(action));
+            intents.emplace_back(anim_intent::AddEvent{ m_clickedFrame });
         }
 
         if (!m_selections.empty() && ImGui::MenuItem("Delete")) {
-            DeleteSelections();
+            intents.emplace_back(anim_intent::DeleteSelections{});
         }
 
         if (eventContext != nullptr && ImGui::BeginMenu("Edit")) {
@@ -829,11 +844,7 @@ bool EditorPanelAnimation::DrawEventPopup() {
         auto const& events = groupEntity->m_events;
         bool const stillExists = std::any_of(events.begin(), events.end(), [&](auto const& e) { return e.get() == m_pendingEventEdit->reference; });
         if (stillExists && m_pendingEventEdit->HasChanged()) {
-            auto action = std::make_unique<ModifyEventAction>(groupEntity, *m_pendingEventEdit->reference, m_pendingEventEdit->mutableValue);
-            m_editorLayer.PerformEditAction(std::move(action));
-            if (auto* selCtx = GetSelectedEventContext(m_pendingEventEdit->reference)) {
-                selCtx->mutableValue = m_pendingEventEdit->mutableValue;
-            }
+            intents.emplace_back(anim_intent::CommitEventEdit{ m_pendingEventEdit->reference, m_pendingEventEdit->mutableValue });
         }
         m_pendingEventEdit.reset();
     }
@@ -849,7 +860,7 @@ void EditorPanelAnimation::DrawEventsRow(std::vector<AnimationIntent>& intents) 
     ImGuiIO const& io = ImGui::GetIO();
     RowDimensions const rowDimensions = AddRow("Events", RowOptions().ColorOverride(kColorRowSpecial));
 
-    bool const popupShown = DrawEventPopup();
+    bool const popupShown = DrawEventPopup(intents);
 
     if (ImGui::IsMouseClicked(ImGuiMouseButton_Left) && popupShown) {
         intents.emplace_back(anim_intent::ConsumeClick{});

--- a/src/editor/panels/editor_panel_animation.cpp
+++ b/src/editor/panels/editor_panel_animation.cpp
@@ -809,7 +809,7 @@ void EditorPanelAnimation::DrawClipRow(std::vector<AnimationIntent>& intents) {
 
 void EditorPanelAnimation::Apply(AnimationIntent const& intent) {
     if (auto const* c = std::get_if<anim_intent::ClickClip>(&intent)) {
-        if (!IsClipSelected(c->clip) && !c->additive) {
+        if (!c->additive) {
             ClearSelections();
         }
         SelectClip(c->clip);
@@ -869,24 +869,20 @@ void EditorPanelAnimation::Apply(AnimationIntent const& intent) {
             m_editorLayer.AddSelection(l->child);
         }
     } else if (auto const* k = std::get_if<anim_intent::ClickKeyframe>(&intent)) {
-        if (!IsKeyframeSelected(k->entity, k->target, k->frame)) {
-            if (!k->additive) {
-                if (k->expanded) {
-                    ClearSelections();
-                } else {
-                    FilterKeyframeSelections(k->entity, k->frame);
-                }
+        if (!k->additive) {
+            if (k->expanded) {
+                ClearSelections();
+            } else {
+                FilterKeyframeSelections(k->entity, k->frame);
             }
         }
         SelectKeyframe(k->entity, k->target, k->frame);
     } else if (auto const* k = std::get_if<anim_intent::ClickDiscreteKeyframe>(&intent)) {
-        if (!IsDiscreteKeyframeSelected(k->entity, k->target, k->frame)) {
-            if (!k->additive) {
-                if (k->expanded) {
-                    ClearSelections();
-                } else {
-                    FilterKeyframeSelections(k->entity, k->frame);
-                }
+        if (!k->additive) {
+            if (k->expanded) {
+                ClearSelections();
+            } else {
+                FilterKeyframeSelections(k->entity, k->frame);
             }
         }
         SelectDiscreteKeyframe(k->entity, k->target, k->frame);
@@ -1857,8 +1853,9 @@ void EditorPanelAnimation::DrawWidget() {
     trackAreaBounds.Min = { m_scrollingPanelBounds.Min.x + m_labelColumnWidth, m_scrollingPanelBounds.Min.y };
     trackAreaBounds.Max = m_scrollingPanelBounds.Max;
 
-    bool const leftClickInTrackArea = m_mouseInScrollArea && trackAreaBounds.Contains(ImGui::GetMousePos()) && ImGui::IsMouseClicked(ImGuiMouseButton_Left);
-    m_clickConsumed = !leftClickInTrackArea;
+    bool const clickInTrackArea = m_mouseInScrollArea && trackAreaBounds.Contains(ImGui::GetMousePos())
+        && (ImGui::IsMouseClicked(ImGuiMouseButton_Left) || ImGui::IsMouseClicked(ImGuiMouseButton_Right));
+    m_clickConsumed = !clickInTrackArea;
 
     m_drawList = ImGui::GetWindowDrawList();
 

--- a/src/editor/panels/editor_panel_animation.cpp
+++ b/src/editor/panels/editor_panel_animation.cpp
@@ -791,6 +791,49 @@ void EditorPanelAnimation::Apply(AnimationIntent const& intent) {
         if (auto* selCtx = GetSelectedEventContext(e->reference)) {
             selCtx->mutableValue = e->newValue;
         }
+    } else if (auto const* l = std::get_if<anim_intent::ClickChildLabel>(&intent)) {
+        if (!l->additive) {
+            m_editorLayer.ClearSelection();
+        }
+        if (m_editorLayer.IsSelected(l->child)) {
+            m_editorLayer.RemoveSelection(l->child);
+        } else {
+            m_editorLayer.AddSelection(l->child);
+        }
+    } else if (auto const* k = std::get_if<anim_intent::ClickKeyframe>(&intent)) {
+        if (!IsKeyframeSelected(k->entity, k->target, k->frame)) {
+            if (!k->additive) {
+                if (k->expanded) {
+                    ClearSelections();
+                } else {
+                    FilterKeyframeSelections(k->entity, k->frame);
+                }
+            }
+        }
+        SelectKeyframe(k->entity, k->target, k->frame);
+    } else if (auto const* k = std::get_if<anim_intent::ClickDiscreteKeyframe>(&intent)) {
+        if (!IsDiscreteKeyframeSelected(k->entity, k->target, k->frame)) {
+            if (!k->additive) {
+                if (k->expanded) {
+                    ClearSelections();
+                } else {
+                    FilterKeyframeSelections(k->entity, k->frame);
+                }
+            }
+        }
+        SelectDiscreteKeyframe(k->entity, k->target, k->frame);
+    } else if (auto const* d = std::get_if<anim_intent::BeginKeyframeDrag>(&intent)) {
+        m_mouseDragging = true;
+        m_mouseDragStartX = d->mouseX;
+        m_altDrag = d->altDrag;
+    } else if (auto const* p = std::get_if<anim_intent::OpenKeyframePopup>(&intent)) {
+        m_clickedChildIdx = p->childIndex;
+        m_clickedChildTarget = p->target;
+        m_clickedTargetIsDiscrete = p->isDiscrete;
+        m_clickedFrame = p->atFrame;
+        ImGui::OpenPopup(KeyframePopupName);
+    } else if (auto const* r = std::get_if<anim_intent::CommitLabelReorder>(&intent)) {
+        m_editorLayer.PerformEditAction(std::make_unique<ChangeIndexAction>(r->node, r->sourceIdx, r->newIndex));
     }
 }
 
@@ -1109,7 +1152,7 @@ bool EditorPanelAnimation::DrawKeyframePopup() {
 // Child track (keyframe rows for one child entity)
 // ---------------------------------------------------------------------------
 
-void EditorPanelAnimation::DrawChildTrack(int childIndex, std::shared_ptr<Node> child) {
+void EditorPanelAnimation::DrawChildTrack(int childIndex, std::shared_ptr<Node> child, std::vector<AnimationIntent>& intents) {
     ImGuiIO const& io = ImGui::GetIO();
 
     auto const childEntity = child->GetLayoutEntity();
@@ -1125,23 +1168,21 @@ void EditorPanelAnimation::DrawChildTrack(int childIndex, std::shared_ptr<Node> 
     }
     RowDimensions const rowDimensions = AddRow(GetChildLabel(childIndex), rowOptions);
 
-    // Toggle expand/collapse.
+    // Toggle expand/collapse. Kept as a direct view-state mutation — it's
+    // per-panel UI state with no undo/external coupling, and the local
+    // `expanded` value gates this-frame sub-row rendering below.
     if (m_mouseInScrollArea && rowDimensions.buttonBounds.Contains(io.MousePos) && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
         expanded = !expanded;
     }
     SetExpanded(child, expanded);
 
     // Click on label to select the entity in the editor (also starts a potential drag).
+    // m_labelDragSourceIdx is per-frame drag bookkeeping that the post-loop
+    // logic in DrawTrackRows reads, so it stays direct; the editor-selection
+    // mutation is the part that goes through Apply.
     if (m_mouseInScrollArea && rowDimensions.labelBounds.Contains(io.MousePos) && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
         m_labelDragSourceIdx = childIndex;
-        if (!io.KeyCtrl) {
-            m_editorLayer.ClearSelection();
-        }
-        if (m_editorLayer.IsSelected(child)) {
-            m_editorLayer.RemoveSelection(child);
-        } else {
-            m_editorLayer.AddSelection(child);
-        }
+        intents.emplace_back(anim_intent::ClickChildLabel{ child, io.KeyCtrl });
     }
 
     // Shared across the continuous and discrete track loops: set to true when any
@@ -1192,35 +1233,21 @@ void EditorPanelAnimation::DrawChildTrack(int childIndex, std::shared_ptr<Node> 
 
             if (ImGui::IsMouseClicked(ImGuiMouseButton_Left) || ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
                 if (m_mouseInScrollArea && frameBounds.Contains(io.MousePos)) {
-                    if (!IsKeyframeSelected(childEntity, target, keyframe->frame)) {
-                        if ((io.KeyMods & ImGuiModFlags_Ctrl) == 0) {
-                            if (expanded) {
-                                ClearSelections();
-                            } else {
-                                // When collapsed, keep sibling-track keyframes at the same frame selected
-                                // so the user can move all tracks at once.
-                                FilterKeyframeSelections(childEntity, keyframe->frame);
-                            }
-                        }
-                    }
-
-                    SelectKeyframe(childEntity, target, keyframe->frame);
-                    m_clickConsumed = true;
+                    intents.emplace_back(anim_intent::ClickKeyframe{ childEntity, target, keyframe->frame, (io.KeyMods & ImGuiModFlags_Ctrl) != 0, expanded });
+                    intents.emplace_back(anim_intent::ConsumeClick{});
 
                     if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
-                        m_mouseDragging = true;
-                        m_mouseDragStartX = io.MousePos.x;
-                        m_altDrag = io.KeyAlt;
+                        intents.emplace_back(anim_intent::BeginKeyframeDrag{ io.MousePos.x, io.KeyAlt });
                     }
                 }
 
                 if (!handledRightClick && ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
                     if (m_mouseInScrollArea && subTrackBounds.Contains(io.MousePos)) {
-                        m_clickedChildIdx = childIndex;
-                        m_clickedChildTarget = expanded ? target : AnimationTrack::Target::Unknown;
-                        m_clickedTargetIsDiscrete = false;
-                        m_clickedFrame = MousePosToFrame(io.MousePos.x, subTrackBounds.Min.x);
-                        ImGui::OpenPopup(KeyframePopupName);
+                        intents.emplace_back(anim_intent::OpenKeyframePopup{
+                            childIndex,
+                            expanded ? target : AnimationTrack::Target::Unknown,
+                            false,
+                            MousePosToFrame(io.MousePos.x, subTrackBounds.Min.x) });
                         handledRightClick = true;
                     }
                 }
@@ -1267,48 +1294,34 @@ void EditorPanelAnimation::DrawChildTrack(int childIndex, std::shared_ptr<Node> 
 
             if (ImGui::IsMouseClicked(ImGuiMouseButton_Left) || ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
                 if (m_mouseInScrollArea && frameBounds.Contains(io.MousePos)) {
-                    if (!IsDiscreteKeyframeSelected(childEntity, target, frame)) {
-                        if ((io.KeyMods & ImGuiModFlags_Ctrl) == 0) {
-                            if (expanded) {
-                                ClearSelections();
-                            } else {
-                                // When collapsed, keep sibling discrete-track keyframes at the same
-                                // frame selected so the user can move all tracks at once.
-                                FilterKeyframeSelections(childEntity, frame);
-                            }
-                        }
-                    }
-                    SelectDiscreteKeyframe(childEntity, target, frame);
-                    m_clickConsumed = true;
+                    intents.emplace_back(anim_intent::ClickDiscreteKeyframe{ childEntity, target, frame, (io.KeyMods & ImGuiModFlags_Ctrl) != 0, expanded });
+                    intents.emplace_back(anim_intent::ConsumeClick{});
 
                     if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
-                        m_mouseDragging = true;
-                        m_mouseDragStartX = io.MousePos.x;
-                        m_altDrag = io.KeyAlt;
+                        intents.emplace_back(anim_intent::BeginKeyframeDrag{ io.MousePos.x, io.KeyAlt });
                     }
                 }
 
                 if (!handledRightClick && ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
                     if (m_mouseInScrollArea && subTrackBounds.Contains(io.MousePos)) {
-                        m_clickedChildIdx = childIndex;
-                        m_clickedChildTarget = target;
-                        m_clickedTargetIsDiscrete = true;
-                        m_clickedFrame = MousePosToFrame(io.MousePos.x, subTrackBounds.Min.x);
-                        ImGui::OpenPopup(KeyframePopupName);
+                        intents.emplace_back(anim_intent::OpenKeyframePopup{
+                            childIndex, target, true,
+                            MousePosToFrame(io.MousePos.x, subTrackBounds.Min.x) });
                         handledRightClick = true;
                     }
                 }
             }
         }
 
-        // Right-click on empty space in discrete track row (no keyframe hit)
+        // Right-click on empty space in discrete track row (no keyframe hit).
+        // Note: original did NOT set handledRightClick here, so when collapsed
+        // (all iterations share subTrackBounds) every track emits an intent and
+        // Apply replays them — last one wins, matching original mutation order.
         if (!handledRightClick && ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
             if (m_mouseInScrollArea && subTrackBounds.Contains(io.MousePos)) {
-                m_clickedChildIdx = childIndex;
-                m_clickedChildTarget = target;
-                m_clickedTargetIsDiscrete = true;
-                m_clickedFrame = MousePosToFrame(io.MousePos.x, subTrackBounds.Min.x);
-                ImGui::OpenPopup(KeyframePopupName);
+                intents.emplace_back(anim_intent::OpenKeyframePopup{
+                    childIndex, target, true,
+                    MousePosToFrame(io.MousePos.x, subTrackBounds.Min.x) });
             }
         }
 
@@ -1316,11 +1329,11 @@ void EditorPanelAnimation::DrawChildTrack(int childIndex, std::shared_ptr<Node> 
     }
 }
 
-void EditorPanelAnimation::DrawTrackRows() {
+void EditorPanelAnimation::DrawTrackRows(std::vector<AnimationIntent>& intents) {
     bool const popupShown = DrawKeyframePopup();
 
     if (ImGui::IsMouseClicked(ImGuiMouseButton_Left) && popupShown) {
-        m_clickConsumed = true;
+        intents.emplace_back(anim_intent::ConsumeClick{});
     }
 
     ImGuiIO const& io = ImGui::GetIO();
@@ -1345,7 +1358,7 @@ void EditorPanelAnimation::DrawTrackRows() {
             m_labelDropLineY = mainRowTopY;
         }
 
-        DrawChildTrack(childIndex, children[childIndex]);
+        DrawChildTrack(childIndex, children[childIndex], intents);
     }
 
     // Mouse is below all rows — drop at the bottom.
@@ -1372,7 +1385,9 @@ void EditorPanelAnimation::DrawTrackRows() {
         m_drawList->AddLine({ x0, m_labelDropLineY }, { x1, m_labelDropLineY }, kColorClipSelected, 2.0f);
     }
 
-    // Update drag state and commit on release.
+    // Update drag state and commit on release. m_labelDragging /
+    // m_labelDragSourceIdx are direct view state; only the ChangeIndexAction
+    // (model-mutating) goes through Apply.
     if (m_labelDragSourceIdx >= 0) {
         if (!m_labelDragging && ImGui::IsMouseDragging(ImGuiMouseButton_Left, 4.0f)) {
             m_labelDragging = true;
@@ -1381,9 +1396,7 @@ void EditorPanelAnimation::DrawTrackRows() {
             if (m_labelDragging && m_labelDragTargetIdx >= 0) {
                 int const newIndex = computeNewIndex();
                 if (newIndex != m_labelDragSourceIdx) {
-                    auto node = children[m_labelDragSourceIdx];
-                    auto action = std::make_unique<ChangeIndexAction>(node, m_labelDragSourceIdx, newIndex);
-                    m_editorLayer.PerformEditAction(std::move(action));
+                    intents.emplace_back(anim_intent::CommitLabelReorder{ children[m_labelDragSourceIdx], m_labelDragSourceIdx, newIndex });
                 }
             }
             m_labelDragSourceIdx = -1;
@@ -1792,7 +1805,8 @@ void EditorPanelAnimation::DrawWidget() {
     drain();
     DrawEventsRow(intents);
     drain();
-    DrawTrackRows();
+    DrawTrackRows(intents);
+    drain();
 
     // Box selection: start tracking on unhandled click in the track area.
     if (m_mouseInScrollArea && !m_clickConsumed) {

--- a/src/editor/panels/editor_panel_animation.cpp
+++ b/src/editor/panels/editor_panel_animation.cpp
@@ -809,12 +809,12 @@ void EditorPanelAnimation::DrawClipRow(std::vector<AnimationIntent>& intents) {
 
 void EditorPanelAnimation::Apply(AnimationIntent const& intent) {
     if (auto const* c = std::get_if<anim_intent::ClickClip>(&intent)) {
-        if (!c->additive) {
+        if (!IsClipSelected(c->clip) && !c->additive) {
             ClearSelections();
         }
         SelectClip(c->clip);
     } else if (auto const* e = std::get_if<anim_intent::ClickEvent>(&intent)) {
-        if (!e->additive) {
+        if (!IsEventSelected(e->event) && !e->additive) {
             ClearSelections();
         }
         SelectEvent(e->event);
@@ -869,20 +869,24 @@ void EditorPanelAnimation::Apply(AnimationIntent const& intent) {
             m_editorLayer.AddSelection(l->child);
         }
     } else if (auto const* k = std::get_if<anim_intent::ClickKeyframe>(&intent)) {
-        if (!k->additive) {
-            if (k->expanded) {
-                ClearSelections();
-            } else {
-                FilterKeyframeSelections(k->entity, k->frame);
+        if (!IsKeyframeSelected(k->entity, k->target, k->frame)) {
+            if (!k->additive) {
+                if (k->expanded) {
+                    ClearSelections();
+                } else {
+                    FilterKeyframeSelections(k->entity, k->frame);
+                }
             }
         }
         SelectKeyframe(k->entity, k->target, k->frame);
     } else if (auto const* k = std::get_if<anim_intent::ClickDiscreteKeyframe>(&intent)) {
-        if (!k->additive) {
-            if (k->expanded) {
-                ClearSelections();
-            } else {
-                FilterKeyframeSelections(k->entity, k->frame);
+        if (!IsDiscreteKeyframeSelected(k->entity, k->target, k->frame)) {
+            if (!k->additive) {
+                if (k->expanded) {
+                    ClearSelections();
+                } else {
+                    FilterKeyframeSelections(k->entity, k->frame);
+                }
             }
         }
         SelectDiscreteKeyframe(k->entity, k->target, k->frame);
@@ -1052,7 +1056,7 @@ void EditorPanelAnimation::DrawEventsRow(std::vector<AnimationIntent>& intents) 
                                       event->frame, event->frame, m_framePixelWidth, slotColor, 2.0f);
         }
 
-        if (ImGui::IsMouseClicked(ImGuiMouseButton_Left) || ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
+        if (!m_mouseDragging && (ImGui::IsMouseClicked(ImGuiMouseButton_Left) || ImGui::IsMouseClicked(ImGuiMouseButton_Right))) {
             if (m_mouseInScrollArea && eventBounds.Contains(io.MousePos)) {
                 intents.emplace_back(anim_intent::ClickEvent{ event.get(), (io.KeyMods & ImGuiModFlags_Ctrl) != 0 });
                 intents.emplace_back(anim_intent::ConsumeClick{});
@@ -1067,7 +1071,7 @@ void EditorPanelAnimation::DrawEventsRow(std::vector<AnimationIntent>& intents) 
     m_drawList->PopClipRect();
 
     // Right-click opens event context menu.
-    if (ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
+    if (!m_mouseDragging && ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
         if (m_mouseInScrollArea && rowDimensions.trackBounds.Contains(io.MousePos)) {
             intents.emplace_back(anim_intent::OpenEventPopup{ MousePosToFrame(io.MousePos.x, rowDimensions.trackBounds.Min.x) });
         }

--- a/src/editor/panels/editor_panel_animation.cpp
+++ b/src/editor/panels/editor_panel_animation.cpp
@@ -740,10 +740,9 @@ void EditorPanelAnimation::DrawClipRow(std::vector<AnimationIntent>& intents) {
     float const trackStartOffsetX = rowDimensions.trackBounds.Min.x + rowDimensions.trackOffset;
     float const trackStartOffsetY = rowDimensions.trackBounds.Min.y;
 
-    // Original code mutated m_mouseDragging inline, which gated subsequent
-    // clips in this loop from entering the click block. Intents defer the
-    // mutation, so we replicate that gate locally for overlapping clips.
-    bool dragIntentEmitted = false;
+    // Gate subsequent clip iterations from also firing on the same click
+    // (relevant when clips overlap). Left and right clicks both consume.
+    bool clickIntentEmitted = false;
 
     auto& animationClips = std::static_pointer_cast<LayoutEntityGroup>(m_group->GetLayoutEntity())->m_clips;
     for (auto&& clip : animationClips) {
@@ -768,7 +767,7 @@ void EditorPanelAnimation::DrawClipRow(std::vector<AnimationIntent>& intents) {
                                       clip->startFrame, clip->endFrame, m_framePixelWidth, slotColor, 2.0f);
         }
 
-        if (!m_mouseDragging && !dragIntentEmitted && m_scrollingPanelBounds.Contains(io.MousePos)) {
+        if (!m_mouseDragging && !clickIntentEmitted && m_scrollingPanelBounds.Contains(io.MousePos)) {
             // Draw hover highlight: body first, edges on top so edge tint shows over the body.
             if (geom.bounds.Contains(io.MousePos)) {
                 m_drawList->AddRectFilled(geom.bounds.Min, geom.bounds.Max, slotColor, 2.0f);
@@ -785,10 +784,10 @@ void EditorPanelAnimation::DrawClipRow(std::vector<AnimationIntent>& intents) {
                 if (hit != kClipHandleNone && (ImGui::IsMouseClicked(ImGuiMouseButton_Left) || ImGui::IsMouseClicked(ImGuiMouseButton_Right))) {
                     intents.emplace_back(anim_intent::ClickClip{ clip.get(), (io.KeyMods & ImGuiModFlags_Ctrl) != 0 });
                     intents.emplace_back(anim_intent::ConsumeClick{});
+                    clickIntentEmitted = true;
 
                     if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
                         intents.emplace_back(anim_intent::BeginClipDrag{ hit, io.MousePos.x });
-                        dragIntentEmitted = true;
                     }
                 }
             }

--- a/src/editor/panels/editor_panel_animation.cpp
+++ b/src/editor/panels/editor_panel_animation.cpp
@@ -101,6 +101,74 @@ namespace {
         return kClipHandleNone;
     }
 
+    struct FrameRange {
+        int start;
+        int end;
+    };
+
+    // Drag math for a single-clip selection. handle is the ClipDragHandle
+    // bitmask captured at drag start; only the edges named by the bitmask are
+    // moved by frameDelta. The other edge keeps its origin value. Clamping
+    // rules: start cannot go below 0 (right edge shifts to preserve width if
+    // both edges move); start cannot exceed end and vice versa per the active
+    // edge.
+    FrameRange ApplyClipDragSingle(int handle, int origStart, int origEnd, int frameDelta) {
+        int l = origStart;
+        int r = origEnd;
+        if ((handle & kClipHandleLeft) != 0) {
+            l = origStart + frameDelta;
+        }
+        if ((handle & kClipHandleRight) != 0) {
+            r = origEnd + frameDelta;
+        }
+        if (l < 0) {
+            if ((handle & kClipHandleRight) != 0) {
+                r -= l; // l is negative, so r shifts right
+            }
+            l = 0;
+        }
+        if ((handle & kClipHandleLeft) != 0 && l > r) {
+            l = r;
+        }
+        if ((handle & kClipHandleRight) != 0 && r < l) {
+            r = l;
+        }
+        return { l, r };
+    }
+
+    // Drag math for a multi-clip selection: rigid translation by frameDelta.
+    // If the result would have start < 0, shift both edges right by -start so
+    // the clip's width is preserved at the left boundary.
+    FrameRange ApplyClipDragMulti(int origStart, int origEnd, int frameDelta) {
+        int start = origStart + frameDelta;
+        int end = origEnd + frameDelta;
+        if (start < 0) {
+            int const shift = -start;
+            start += shift;
+            end += shift;
+        }
+        return { start, end };
+    }
+
+    // Sort discrete-keyframe move records to avoid clobbering when multiple
+    // moves on the same track go the same direction: when moving right,
+    // process highest source-frame first; when moving left, lowest first.
+    // This ensures each action reads its source before any later action
+    // overwrites that slot.
+    void SortDiscreteMovesForCommit(std::vector<DiscreteKeyframeContext const*>& moves) {
+        if (moves.empty()) { return; }
+        bool const movingRight = moves.front()->mutableFrame > moves.front()->frame;
+        if (movingRight) {
+            std::sort(moves.begin(), moves.end(), [](auto const* a, auto const* b) {
+                return a->frame > b->frame;
+            });
+        } else {
+            std::sort(moves.begin(), moves.end(), [](auto const* a, auto const* b) {
+                return a->frame < b->frame;
+            });
+        }
+    }
+
     // Reserves space in the scrolling panel so ImGui knows how big the content is.
     void AddScrollPanelItem(ImVec2 const& size_arg) {
         ImGuiWindow* window = ImGui::GetCurrentWindow();
@@ -1935,16 +2003,7 @@ void EditorPanelAnimation::CommitDragActions() {
         }
     }
     if (!discreteMoveCtxs.empty()) {
-        bool const movingRight = discreteMoveCtxs.front()->mutableFrame > discreteMoveCtxs.front()->frame;
-        if (movingRight) {
-            std::sort(discreteMoveCtxs.begin(), discreteMoveCtxs.end(), [](auto const* a, auto const* b) {
-                return a->frame > b->frame;
-            });
-        } else {
-            std::sort(discreteMoveCtxs.begin(), discreteMoveCtxs.end(), [](auto const* a, auto const* b) {
-                return a->frame < b->frame;
-            });
-        }
+        SortDiscreteMovesForCommit(discreteMoveCtxs);
         for (auto const* dkfCtx : discreteMoveCtxs) {
             auto it = dkfCtx->entity->m_discreteTracks.find(dkfCtx->target);
             auto* val = it->second.GetKeyframe(dkfCtx->frame);
@@ -1970,39 +2029,11 @@ void EditorPanelAnimation::UpdateMouseDragging() {
 
     for (auto& context : m_selections) {
         if (auto* clipCtx = std::get_if<ClipContext>(&context)) {
-            // Single clip: the drag handle determines whether we move the left edge, right edge, or both.
-            if (m_selections.size() == 1) {
-                int& l = clipCtx->mutableValue.startFrame;
-                int& r = clipCtx->mutableValue.endFrame;
-                if ((m_clipDragHandle & kClipHandleLeft) != 0) {
-                    l = clipCtx->clip->startFrame + frameDelta;
-                }
-                if ((m_clipDragHandle & kClipHandleRight) != 0) {
-                    r = clipCtx->clip->endFrame + frameDelta;
-                }
-                if (l < 0) {
-                    if ((m_clipDragHandle & kClipHandleRight) != 0) {
-                        r -= l;
-                    }
-                    l = 0;
-                }
-                if ((m_clipDragHandle & kClipHandleLeft) != 0 && l > r) {
-                    l = r;
-                }
-                if ((m_clipDragHandle & kClipHandleRight) != 0 && r < l) {
-                    r = l;
-                }
-            } else {
-                int start = clipCtx->clip->startFrame + frameDelta;
-                int end = clipCtx->clip->endFrame + frameDelta;
-                if (start < 0) {
-                    int const shift = -start;
-                    start += shift;
-                    end += shift;
-                }
-                clipCtx->mutableValue.startFrame = start;
-                clipCtx->mutableValue.endFrame = end;
-            }
+            FrameRange const range = (m_selections.size() == 1)
+                ? ApplyClipDragSingle(m_clipDragHandle, clipCtx->clip->startFrame, clipCtx->clip->endFrame, frameDelta)
+                : ApplyClipDragMulti(clipCtx->clip->startFrame, clipCtx->clip->endFrame, frameDelta);
+            clipCtx->mutableValue.startFrame = range.start;
+            clipCtx->mutableValue.endFrame = range.end;
         } else if (auto* eventCtx = std::get_if<EventContext>(&context)) {
             int frame = eventCtx->event->frame + frameDelta;
             frame = std::max(frame, 0);

--- a/src/editor/panels/editor_panel_animation.cpp
+++ b/src/editor/panels/editor_panel_animation.cpp
@@ -753,15 +753,26 @@ void EditorPanelAnimation::Apply(AnimationIntent const& intent) {
             ClearSelections();
         }
         SelectClip(c->clip);
+    } else if (auto const* e = std::get_if<anim_intent::ClickEvent>(&intent)) {
+        if (!e->additive) {
+            ClearSelections();
+        }
+        SelectEvent(e->event);
     } else if (std::holds_alternative<anim_intent::ConsumeClick>(intent)) {
         m_clickConsumed = true;
     } else if (auto const* d = std::get_if<anim_intent::BeginClipDrag>(&intent)) {
         m_mouseDragging = true;
         m_mouseDragStartX = d->mouseX;
         m_clipDragHandle = d->handle;
+    } else if (auto const* d = std::get_if<anim_intent::BeginEventDrag>(&intent)) {
+        m_mouseDragging = true;
+        m_mouseDragStartX = d->mouseX;
     } else if (auto const* p = std::get_if<anim_intent::OpenClipPopup>(&intent)) {
         m_clickedFrame = p->atFrame;
         ImGui::OpenPopup(ClipPopupName);
+    } else if (auto const* p = std::get_if<anim_intent::OpenEventPopup>(&intent)) {
+        m_clickedFrame = p->atFrame;
+        ImGui::OpenPopup(EventPopupName);
     }
 }
 
@@ -834,14 +845,14 @@ bool EditorPanelAnimation::DrawEventPopup() {
 // Events row
 // ---------------------------------------------------------------------------
 
-void EditorPanelAnimation::DrawEventsRow() {
+void EditorPanelAnimation::DrawEventsRow(std::vector<AnimationIntent>& intents) {
     ImGuiIO const& io = ImGui::GetIO();
     RowDimensions const rowDimensions = AddRow("Events", RowOptions().ColorOverride(kColorRowSpecial));
 
     bool const popupShown = DrawEventPopup();
 
     if (ImGui::IsMouseClicked(ImGuiMouseButton_Left) && popupShown) {
-        m_clickConsumed = true;
+        intents.emplace_back(anim_intent::ConsumeClick{});
     }
 
     m_drawList->PushClipRect(rowDimensions.trackBounds.Min, rowDimensions.trackBounds.Max, true);
@@ -883,16 +894,11 @@ void EditorPanelAnimation::DrawEventsRow() {
 
         if (ImGui::IsMouseClicked(ImGuiMouseButton_Left) || ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
             if (m_mouseInScrollArea && eventBounds.Contains(io.MousePos)) {
-                if ((io.KeyMods & ImGuiModFlags_Ctrl) == 0) {
-                    ClearSelections();
-                }
-
-                SelectEvent(event.get());
-                m_clickConsumed = true;
+                intents.emplace_back(anim_intent::ClickEvent{ event.get(), (io.KeyMods & ImGuiModFlags_Ctrl) != 0 });
+                intents.emplace_back(anim_intent::ConsumeClick{});
 
                 if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
-                    m_mouseDragging = true;
-                    m_mouseDragStartX = io.MousePos.x;
+                    intents.emplace_back(anim_intent::BeginEventDrag{ io.MousePos.x });
                 }
             }
         }
@@ -903,8 +909,7 @@ void EditorPanelAnimation::DrawEventsRow() {
     // Right-click opens event context menu.
     if (ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
         if (m_mouseInScrollArea && rowDimensions.trackBounds.Contains(io.MousePos)) {
-            m_clickedFrame = MousePosToFrame(io.MousePos.x, rowDimensions.trackBounds.Min.x);
-            ImGui::OpenPopup(EventPopupName);
+            intents.emplace_back(anim_intent::OpenEventPopup{ MousePosToFrame(io.MousePos.x, rowDimensions.trackBounds.Min.x) });
         }
     }
 }
@@ -1762,15 +1767,20 @@ void EditorPanelAnimation::DrawWidget() {
     m_pendingClipBoxSelections.clear();
     m_pendingEventBoxSelections.clear();
 
+    // Each row emits intents, drained before the next row runs so subsequent
+    // rows observe this row's state mutations (e.g. m_mouseDragging).
     std::vector<AnimationIntent> intents;
-    DrawClipRow(intents);
-    // Drain before subsequent rows: DrawEventsRow/DrawTrackRows read
-    // m_mouseDragging/m_clickConsumed and must observe this row's mutations.
-    for (auto const& intent : intents) {
-        Apply(intent);
-    }
+    auto drain = [&] {
+        for (auto const& intent : intents) {
+            Apply(intent);
+        }
+        intents.clear();
+    };
 
-    DrawEventsRow();
+    DrawClipRow(intents);
+    drain();
+    DrawEventsRow(intents);
+    drain();
     DrawTrackRows();
 
     // Box selection: start tracking on unhandled click in the track area.

--- a/src/editor/panels/editor_panel_animation.cpp
+++ b/src/editor/panels/editor_panel_animation.cpp
@@ -809,15 +809,23 @@ void EditorPanelAnimation::DrawClipRow(std::vector<AnimationIntent>& intents) {
 
 void EditorPanelAnimation::Apply(AnimationIntent const& intent) {
     if (auto const* c = std::get_if<anim_intent::ClickClip>(&intent)) {
-        if (!IsClipSelected(c->clip) && !c->additive) {
-            ClearSelections();
+        if (c->additive && IsClipSelected(c->clip)) {
+            DeselectClip(c->clip);
+        } else if (!IsClipSelected(c->clip)) {
+            if (!c->additive) {
+                ClearSelections();
+            }
+            SelectClip(c->clip);
         }
-        SelectClip(c->clip);
     } else if (auto const* e = std::get_if<anim_intent::ClickEvent>(&intent)) {
-        if (!IsEventSelected(e->event) && !e->additive) {
-            ClearSelections();
+        if (e->additive && IsEventSelected(e->event)) {
+            DeselectEvent(e->event);
+        } else if (!IsEventSelected(e->event)) {
+            if (!e->additive) {
+                ClearSelections();
+            }
+            SelectEvent(e->event);
         }
-        SelectEvent(e->event);
     } else if (std::holds_alternative<anim_intent::ConsumeClick>(intent)) {
         m_clickConsumed = true;
     } else if (auto const* d = std::get_if<anim_intent::BeginClipDrag>(&intent)) {
@@ -869,7 +877,9 @@ void EditorPanelAnimation::Apply(AnimationIntent const& intent) {
             m_editorLayer.AddSelection(l->child);
         }
     } else if (auto const* k = std::get_if<anim_intent::ClickKeyframe>(&intent)) {
-        if (!IsKeyframeSelected(k->entity, k->target, k->frame)) {
+        if (k->additive && IsKeyframeSelected(k->entity, k->target, k->frame)) {
+            DeselectKeyframe(k->entity, k->target, k->frame);
+        } else if (!IsKeyframeSelected(k->entity, k->target, k->frame)) {
             if (!k->additive) {
                 if (k->expanded) {
                     ClearSelections();
@@ -877,10 +887,12 @@ void EditorPanelAnimation::Apply(AnimationIntent const& intent) {
                     FilterKeyframeSelections(k->entity, k->frame);
                 }
             }
+            SelectKeyframe(k->entity, k->target, k->frame);
         }
-        SelectKeyframe(k->entity, k->target, k->frame);
     } else if (auto const* k = std::get_if<anim_intent::ClickDiscreteKeyframe>(&intent)) {
-        if (!IsDiscreteKeyframeSelected(k->entity, k->target, k->frame)) {
+        if (k->additive && IsDiscreteKeyframeSelected(k->entity, k->target, k->frame)) {
+            DeselectDiscreteKeyframe(k->entity, k->target, k->frame);
+        } else if (!IsDiscreteKeyframeSelected(k->entity, k->target, k->frame)) {
             if (!k->additive) {
                 if (k->expanded) {
                     ClearSelections();
@@ -888,8 +900,8 @@ void EditorPanelAnimation::Apply(AnimationIntent const& intent) {
                     FilterKeyframeSelections(k->entity, k->frame);
                 }
             }
+            SelectDiscreteKeyframe(k->entity, k->target, k->frame);
         }
-        SelectDiscreteKeyframe(k->entity, k->target, k->frame);
     } else if (auto const* d = std::get_if<anim_intent::BeginKeyframeDrag>(&intent)) {
         m_mouseDragging = true;
         m_mouseDragStartX = d->mouseX;

--- a/src/editor/panels/editor_panel_animation.cpp
+++ b/src/editor/panels/editor_panel_animation.cpp
@@ -663,7 +663,7 @@ bool EditorPanelAnimation::DrawClipPopup() {
 // Clip row
 // ---------------------------------------------------------------------------
 
-void EditorPanelAnimation::DrawClipRow() {
+void EditorPanelAnimation::DrawClipRow(std::vector<AnimationIntent>& intents) {
     RowDimensions const rowDimensions = AddRow("Clips", RowOptions().ColorOverride(kColorRowSpecial));
 
     ImGuiIO const& io = ImGui::GetIO();
@@ -672,13 +672,18 @@ void EditorPanelAnimation::DrawClipRow() {
 
     // Cancel pending selection clear if we click in a popup.
     if (ImGui::IsMouseClicked(ImGuiMouseButton_Left) && popupShown) {
-        m_clickConsumed = true;
+        intents.emplace_back(anim_intent::ConsumeClick{});
     }
 
     m_drawList->PushClipRect(rowDimensions.trackBounds.Min, rowDimensions.trackBounds.Max, true);
 
     float const trackStartOffsetX = rowDimensions.trackBounds.Min.x + rowDimensions.trackOffset;
     float const trackStartOffsetY = rowDimensions.trackBounds.Min.y;
+
+    // Original code mutated m_mouseDragging inline, which gated subsequent
+    // clips in this loop from entering the click block. Intents defer the
+    // mutation, so we replicate that gate locally for overlapping clips.
+    bool dragIntentEmitted = false;
 
     auto& animationClips = std::static_pointer_cast<LayoutEntityGroup>(m_group->GetLayoutEntity())->m_clips;
     for (auto&& clip : animationClips) {
@@ -703,7 +708,7 @@ void EditorPanelAnimation::DrawClipRow() {
                                       clip->startFrame, clip->endFrame, m_framePixelWidth, slotColor, 2.0f);
         }
 
-        if (!m_mouseDragging && m_scrollingPanelBounds.Contains(io.MousePos)) {
+        if (!m_mouseDragging && !dragIntentEmitted && m_scrollingPanelBounds.Contains(io.MousePos)) {
             // Draw hover highlight: body first, edges on top so edge tint shows over the body.
             if (geom.bounds.Contains(io.MousePos)) {
                 m_drawList->AddRectFilled(geom.bounds.Min, geom.bounds.Max, slotColor, 2.0f);
@@ -718,19 +723,12 @@ void EditorPanelAnimation::DrawClipRow() {
             if (m_mouseInScrollArea && io.MousePos.x >= rowDimensions.trackBounds.Min.x && io.MousePos.x <= rowDimensions.trackBounds.Max.x) {
                 int const hit = HitTestClip(geom, io.MousePos);
                 if (hit != kClipHandleNone && (ImGui::IsMouseClicked(ImGuiMouseButton_Left) || ImGui::IsMouseClicked(ImGuiMouseButton_Right))) {
-                    if (!IsClipSelected(clip.get())) {
-                        if ((io.KeyMods & ImGuiModFlags_Ctrl) == 0) {
-                            ClearSelections();
-                        }
-                    }
-
-                    SelectClip(clip.get());
-                    m_clickConsumed = true;
+                    intents.emplace_back(anim_intent::ClickClip{ clip.get(), (io.KeyMods & ImGuiModFlags_Ctrl) != 0 });
+                    intents.emplace_back(anim_intent::ConsumeClick{});
 
                     if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
-                        m_mouseDragging = true;
-                        m_mouseDragStartX = io.MousePos.x;
-                        m_clipDragHandle = hit;
+                        intents.emplace_back(anim_intent::BeginClipDrag{ hit, io.MousePos.x });
+                        dragIntentEmitted = true;
                     }
                 }
             }
@@ -745,7 +743,24 @@ void EditorPanelAnimation::DrawClipRow() {
 
     // Right-click opens clip context menu.
     if (m_mouseInScrollArea && rowDimensions.trackBounds.Contains(io.MousePos) && ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
-        m_clickedFrame = MousePosToFrame(io.MousePos.x, rowDimensions.trackBounds.Min.x);
+        intents.emplace_back(anim_intent::OpenClipPopup{ MousePosToFrame(io.MousePos.x, rowDimensions.trackBounds.Min.x) });
+    }
+}
+
+void EditorPanelAnimation::Apply(AnimationIntent const& intent) {
+    if (auto const* c = std::get_if<anim_intent::ClickClip>(&intent)) {
+        if (!IsClipSelected(c->clip) && !c->additive) {
+            ClearSelections();
+        }
+        SelectClip(c->clip);
+    } else if (std::holds_alternative<anim_intent::ConsumeClick>(intent)) {
+        m_clickConsumed = true;
+    } else if (auto const* d = std::get_if<anim_intent::BeginClipDrag>(&intent)) {
+        m_mouseDragging = true;
+        m_mouseDragStartX = d->mouseX;
+        m_clipDragHandle = d->handle;
+    } else if (auto const* p = std::get_if<anim_intent::OpenClipPopup>(&intent)) {
+        m_clickedFrame = p->atFrame;
         ImGui::OpenPopup(ClipPopupName);
     }
 }
@@ -1747,7 +1762,14 @@ void EditorPanelAnimation::DrawWidget() {
     m_pendingClipBoxSelections.clear();
     m_pendingEventBoxSelections.clear();
 
-    DrawClipRow();
+    std::vector<AnimationIntent> intents;
+    DrawClipRow(intents);
+    // Drain before subsequent rows: DrawEventsRow/DrawTrackRows read
+    // m_mouseDragging/m_clickConsumed and must observe this row's mutations.
+    for (auto const& intent : intents) {
+        Apply(intent);
+    }
+
     DrawEventsRow();
     DrawTrackRows();
 

--- a/src/editor/panels/editor_panel_animation.cpp
+++ b/src/editor/panels/editor_panel_animation.cpp
@@ -834,6 +834,48 @@ void EditorPanelAnimation::Apply(AnimationIntent const& intent) {
         ImGui::OpenPopup(KeyframePopupName);
     } else if (auto const* r = std::get_if<anim_intent::CommitLabelReorder>(&intent)) {
         m_editorLayer.PerformEditAction(std::make_unique<ChangeIndexAction>(r->node, r->sourceIdx, r->newIndex));
+    } else if (auto const* a = std::get_if<anim_intent::AddDiscreteKeyframe>(&intent)) {
+        auto& discreteTracks = a->entity->m_discreteTracks;
+        auto dtIt = discreteTracks.find(a->target);
+        std::string seedValue;
+        if (dtIt != discreteTracks.end()) {
+            seedValue = dtIt->second.GetValueAtFrame(a->frame);
+        }
+        m_editorLayer.PerformEditAction(std::make_unique<AddDiscreteKeyframeAction>(a->entity, a->target, a->frame, std::move(seedValue)));
+    } else if (auto const* a = std::get_if<anim_intent::AddContinuousKeyframes>(&intent)) {
+        auto& childTracks = a->entity->m_tracks;
+        if (a->target != AnimationTrack::Target::Unknown) {
+            auto* trackPtr = childTracks.at(a->target).get();
+            auto const currentValue = trackPtr->GetValueAtFrame(static_cast<float>(a->frame));
+            std::unique_ptr<IEditorAction> action = std::make_unique<AddKeyframeAction>(a->entity, a->target, a->frame, currentValue, moth_ui::InterpType::Linear);
+            action->Do();
+            m_editorLayer.AddEditAction(std::move(action));
+        } else {
+            std::unique_ptr<CompositeAction> compositeAction = std::make_unique<CompositeAction>();
+            for (auto&& target : AnimationTrack::ContinuousTargets) {
+                auto* trackPtr = childTracks.at(target).get();
+                if (nullptr == trackPtr->GetKeyframe(a->frame)) {
+                    auto const currentValue = trackPtr->GetValueAtFrame(static_cast<float>(a->frame));
+                    auto action = std::make_unique<AddKeyframeAction>(a->entity, target, a->frame, currentValue, moth_ui::InterpType::Linear);
+                    action->Do();
+                    compositeAction->GetActions().push_back(std::move(action));
+                }
+            }
+            m_editorLayer.AddEditAction(std::move(compositeAction));
+        }
+    } else if (auto const* s = std::get_if<anim_intent::SetDiscreteKeyframeValue>(&intent)) {
+        m_editorLayer.PerformEditAction(std::make_unique<AddDiscreteKeyframeAction>(s->entity, s->target, s->frame, s->value));
+    } else if (auto const* i = std::get_if<anim_intent::CommitInterpChange>(&intent)) {
+        auto compositeAction = std::make_unique<CompositeAction>();
+        for (auto&& context : m_selections) {
+            if (auto* kfCtx = std::get_if<KeyframeContext>(&context)) {
+                auto action = MakeChangeValueAction(kfCtx->current->interpType, kfCtx->current->interpType, i->interpType, nullptr);
+                compositeAction->GetActions().push_back(std::move(action));
+            }
+        }
+        if (!compositeAction->GetActions().empty()) {
+            m_editorLayer.PerformEditAction(std::move(compositeAction));
+        }
     }
 }
 
@@ -972,7 +1014,7 @@ void EditorPanelAnimation::DrawEventsRow(std::vector<AnimationIntent>& intents) 
 // Keyframe popup (right-click context menu on keyframe tracks)
 // ---------------------------------------------------------------------------
 
-bool EditorPanelAnimation::DrawKeyframePopup() {
+bool EditorPanelAnimation::DrawKeyframePopup(std::vector<AnimationIntent>& intents) {
     if (ImGui::BeginPopup(KeyframePopupName)) {
         auto const child = m_group->GetChildren()[m_clickedChildIdx];
         auto const childEntity = child->GetLayoutEntity();
@@ -984,16 +1026,11 @@ bool EditorPanelAnimation::DrawKeyframePopup() {
             bool keyframeAtFrame = (dtIt != discreteTracks.end()) && (dtIt->second.GetKeyframe(m_clickedFrame) != nullptr);
 
             if (!keyframeAtFrame && ImGui::MenuItem("Add")) {
-                std::string seedValue;
-                if (dtIt != discreteTracks.end()) {
-                    seedValue = dtIt->second.GetValueAtFrame(m_clickedFrame);
-                }
-                auto action = std::make_unique<AddDiscreteKeyframeAction>(childEntity, m_clickedChildTarget, m_clickedFrame, std::move(seedValue));
-                m_editorLayer.PerformEditAction(std::move(action));
+                intents.emplace_back(anim_intent::AddDiscreteKeyframe{ childEntity, m_clickedChildTarget, m_clickedFrame });
             }
 
             if (!m_selections.empty() && ImGui::MenuItem("Delete")) {
-                DeleteSelections();
+                intents.emplace_back(anim_intent::DeleteSelections{});
             }
 
             // Edit value for the selected discrete keyframe.
@@ -1045,8 +1082,7 @@ bool EditorPanelAnimation::DrawKeyframePopup() {
                         }
 
                         if (valueChanged) {
-                            auto addAction = std::make_unique<AddDiscreteKeyframeAction>(childEntity, m_clickedChildTarget, dkfCtx->frame, std::move(newValue));
-                            m_editorLayer.PerformEditAction(std::move(addAction));
+                            intents.emplace_back(anim_intent::SetDiscreteKeyframeValue{ childEntity, m_clickedChildTarget, dkfCtx->frame, std::move(newValue) });
                             ImGui::CloseCurrentPopup();
                         }
                     }
@@ -1075,30 +1111,11 @@ bool EditorPanelAnimation::DrawKeyframePopup() {
         }
 
         if (!keyframeAtFrame && ImGui::MenuItem("Add")) {
-            if (m_clickedChildTarget != AnimationTrack::Target::Unknown) {
-                // Clicked on a specific sub-track: add one keyframe.
-                auto const currentValue = trackPtr->GetValueAtFrame(static_cast<float>(m_clickedFrame));
-                std::unique_ptr<IEditorAction> action = std::make_unique<AddKeyframeAction>(childEntity, m_clickedChildTarget, m_clickedFrame, currentValue, moth_ui::InterpType::Linear);
-                action->Do();
-                m_editorLayer.AddEditAction(std::move(action));
-            } else {
-                // Clicked on the collapsed main track: add keyframes on all continuous targets.
-                std::unique_ptr<CompositeAction> compositeAction = std::make_unique<CompositeAction>();
-                for (auto&& target : AnimationTrack::ContinuousTargets) {
-                    trackPtr = childTracks.at(target).get();
-                    if (nullptr == trackPtr->GetKeyframe(m_clickedFrame)) {
-                        auto const currentValue = trackPtr->GetValueAtFrame(static_cast<float>(m_clickedFrame));
-                        auto action = std::make_unique<AddKeyframeAction>(childEntity, target, m_clickedFrame, currentValue, moth_ui::InterpType::Linear);
-                        action->Do();
-                        compositeAction->GetActions().push_back(std::move(action));
-                    }
-                }
-                m_editorLayer.AddEditAction(std::move(compositeAction));
-            }
+            intents.emplace_back(anim_intent::AddContinuousKeyframes{ childEntity, m_clickedChildTarget, m_clickedFrame });
         }
 
         if (!m_selections.empty() && ImGui::MenuItem("Delete")) {
-            DeleteSelections();
+            intents.emplace_back(anim_intent::DeleteSelections{});
         }
 
         if (!m_selections.empty() && ImGui::BeginMenu("Interp")) {
@@ -1127,16 +1144,7 @@ bool EditorPanelAnimation::DrawKeyframePopup() {
                 std::string const interpName(magic_enum::enum_name(interpType));
                 bool checked = selectedInterp == interpType;
                 if (ImGui::RadioButton(interpName.c_str(), checked)) {
-                    auto compositeAction = std::make_unique<CompositeAction>();
-                    for (auto&& context : m_selections) {
-                        if (auto* kfCtx = std::get_if<KeyframeContext>(&context)) {
-                            auto action = MakeChangeValueAction(kfCtx->current->interpType, kfCtx->current->interpType, interpType, nullptr);
-                            compositeAction->GetActions().push_back(std::move(action));
-                        }
-                    }
-                    if (!compositeAction->GetActions().empty()) {
-                        m_editorLayer.PerformEditAction(std::move(compositeAction));
-                    }
+                    intents.emplace_back(anim_intent::CommitInterpChange{ interpType });
                 }
             }
             ImGui::EndMenu();
@@ -1330,7 +1338,7 @@ void EditorPanelAnimation::DrawChildTrack(int childIndex, std::shared_ptr<Node> 
 }
 
 void EditorPanelAnimation::DrawTrackRows(std::vector<AnimationIntent>& intents) {
-    bool const popupShown = DrawKeyframePopup();
+    bool const popupShown = DrawKeyframePopup(intents);
 
     if (ImGui::IsMouseClicked(ImGuiMouseButton_Left) && popupShown) {
         intents.emplace_back(anim_intent::ConsumeClick{});

--- a/src/editor/panels/editor_panel_animation.cpp
+++ b/src/editor/panels/editor_panel_animation.cpp
@@ -70,6 +70,37 @@ namespace {
         drawList->AddRectFilled(boundsMin, boundsMax, color, rounding);
     }
 
+    // Rectangles describing a clip's interactive regions on the timeline.
+    // Left/right edges are resize handles; bounds is the full clip body.
+    struct ClipGeometry {
+        ImRect bounds;
+        ImRect leftEdge;
+        ImRect rightEdge;
+    };
+
+    ClipGeometry ComputeClipGeometry(int startFrame, int endFrame, float framePixelWidth,
+                                     float trackStartOffsetX, float trackStartOffsetY, float rowHeight) {
+        float const startOffset = static_cast<float>(startFrame) * framePixelWidth;
+        float const endOffset = static_cast<float>(endFrame + 1) * framePixelWidth;
+        float const edgeWidth = framePixelWidth / 2.0f;
+        ImVec2 const minP{ trackStartOffsetX + startOffset, trackStartOffsetY + 2.0f };
+        ImVec2 const maxP{ trackStartOffsetX + endOffset, trackStartOffsetY + rowHeight - 2.0f };
+        return ClipGeometry{
+            ImRect{ minP, maxP },
+            ImRect{ minP, ImVec2{ minP.x + edgeWidth, maxP.y } },
+            ImRect{ ImVec2{ maxP.x - edgeWidth, minP.y }, maxP }
+        };
+    }
+
+    // Returns kClipHandleLeft/Right/Center for the region under mousePos, or
+    // kClipHandleNone if outside. Edges take priority over the body.
+    int HitTestClip(ClipGeometry const& geom, ImVec2 const& mousePos) {
+        if (geom.leftEdge.Contains(mousePos))  { return kClipHandleLeft; }
+        if (geom.rightEdge.Contains(mousePos)) { return kClipHandleRight; }
+        if (geom.bounds.Contains(mousePos))    { return kClipHandleCenter; }
+        return kClipHandleNone;
+    }
+
     // Reserves space in the scrolling panel so ImGui knows how big the content is.
     void AddScrollPanelItem(ImVec2 const& size_arg) {
         ImGuiWindow* window = ImGui::GetCurrentWindow();
@@ -655,18 +686,16 @@ void EditorPanelAnimation::DrawClipRow() {
 
         auto& clipValues = (m_mouseDragging && selected) ? GetSelectedClipContext(clip.get())->mutableValue : *clip; // NOLINT(clang-analyzer-core.NullDereference)
 
-        float const clipStartOffset = static_cast<float>(clipValues.startFrame) * m_framePixelWidth;
-        float const clipEndOffset = static_cast<float>(clipValues.endFrame + 1) * m_framePixelWidth;
-        ImVec2 const clipBoundsMin{ trackStartOffsetX + clipStartOffset, trackStartOffsetY + 2.0f };
-        ImVec2 const clipBoundsMax{ trackStartOffsetX + clipEndOffset, trackStartOffsetY + m_rowHeight - 2.0f };
+        ClipGeometry const geom = ComputeClipGeometry(clipValues.startFrame, clipValues.endFrame,
+                                                      m_framePixelWidth, trackStartOffsetX, trackStartOffsetY, m_rowHeight);
 
-        if (m_boxSelecting && ImRect{ clipBoundsMin, clipBoundsMax }.Overlaps(m_selectBox)) {
+        if (m_boxSelecting && geom.bounds.Overlaps(m_selectBox)) {
             m_pendingClipBoxSelections.push_back(clip.get());
             selected = true;
         }
 
         unsigned int const slotColor = selected ? kColorClipSelected : kColorClip;
-        m_drawList->AddRectFilled(clipBoundsMin, clipBoundsMax, slotColor, 2.0f);
+        m_drawList->AddRectFilled(geom.bounds.Min, geom.bounds.Max, slotColor, 2.0f);
 
         // Alt-drag duplicates: show the original clip in place.
         if (io.KeyAlt) {
@@ -674,55 +703,41 @@ void EditorPanelAnimation::DrawClipRow() {
                                       clip->startFrame, clip->endFrame, m_framePixelWidth, slotColor, 2.0f);
         }
 
-        // The clip has three interactive regions: left edge, right edge, and center body.
-        // Left/right edges resize; center moves the whole clip.
-        float const clipEdgeWidth = m_framePixelWidth / 2.0f;
-        ImRect const hitRegions[3] = {
-            ImRect{ clipBoundsMin, ImVec2{ clipBoundsMin.x + clipEdgeWidth, clipBoundsMax.y } },
-            ImRect{ ImVec2{ clipBoundsMax.x - clipEdgeWidth, clipBoundsMin.y }, clipBoundsMax },
-            ImRect{ clipBoundsMin, clipBoundsMax }
-        };
-
-        unsigned int const hoverColor[] = { kColorTextPrimary, kColorTextPrimary, slotColor };
         if (!m_mouseDragging && m_scrollingPanelBounds.Contains(io.MousePos)) {
-            // Draw hover highlight (check center last so edges take priority).
-            for (int i = 2; i >= 0; --i) {
-                if (hitRegions[i].Contains(io.MousePos)) {
-                    m_drawList->AddRectFilled(hitRegions[i].Min, hitRegions[i].Max, hoverColor[i], 2.0f);
-                }
+            // Draw hover highlight: body first, edges on top so edge tint shows over the body.
+            if (geom.bounds.Contains(io.MousePos)) {
+                m_drawList->AddRectFilled(geom.bounds.Min, geom.bounds.Max, slotColor, 2.0f);
+            }
+            if (geom.rightEdge.Contains(io.MousePos)) {
+                m_drawList->AddRectFilled(geom.rightEdge.Min, geom.rightEdge.Max, kColorTextPrimary, 2.0f);
+            }
+            if (geom.leftEdge.Contains(io.MousePos)) {
+                m_drawList->AddRectFilled(geom.leftEdge.Min, geom.leftEdge.Max, kColorTextPrimary, 2.0f);
             }
 
-            if (io.MousePos.x >= rowDimensions.trackBounds.Min.x && io.MousePos.x <= rowDimensions.trackBounds.Max.x) {
-                // Check hit regions for click (edges first so they take priority over center).
-                for (int j = 0; j < 3; j++) {
-                    if (!m_mouseInScrollArea || !hitRegions[j].Contains(io.MousePos)) {
-                        continue;
+            if (m_mouseInScrollArea && io.MousePos.x >= rowDimensions.trackBounds.Min.x && io.MousePos.x <= rowDimensions.trackBounds.Max.x) {
+                int const hit = HitTestClip(geom, io.MousePos);
+                if (hit != kClipHandleNone && (ImGui::IsMouseClicked(ImGuiMouseButton_Left) || ImGui::IsMouseClicked(ImGuiMouseButton_Right))) {
+                    if (!IsClipSelected(clip.get())) {
+                        if ((io.KeyMods & ImGuiModFlags_Ctrl) == 0) {
+                            ClearSelections();
+                        }
                     }
 
-                    if (ImGui::IsMouseClicked(ImGuiMouseButton_Left) || ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
-                        if (!IsClipSelected(clip.get())) {
-                            if ((io.KeyMods & ImGuiModFlags_Ctrl) == 0) {
-                                ClearSelections();
-                            }
-                        }
+                    SelectClip(clip.get());
+                    m_clickConsumed = true;
 
-                        SelectClip(clip.get());
-                        m_clickConsumed = true;
-
-                        if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
-                            m_mouseDragging = true;
-                            m_mouseDragStartX = io.MousePos.x;
-                            static constexpr int kHandleForRegion[3] = { kClipHandleLeft, kClipHandleRight, kClipHandleCenter };
-                            m_clipDragHandle = kHandleForRegion[j];
-                            break;
-                        }
+                    if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+                        m_mouseDragging = true;
+                        m_mouseDragStartX = io.MousePos.x;
+                        m_clipDragHandle = hit;
                     }
                 }
             }
         }
 
         ImVec2 const textSize = ImGui::CalcTextSize(clip->name.c_str());
-        ImVec2 const textPos(clipBoundsMin.x + ((clipBoundsMax.x - clipBoundsMin.x - textSize.x) / 2), clipBoundsMin.y + ((clipBoundsMax.y - clipBoundsMin.y - textSize.y) / 2));
+        ImVec2 const textPos(geom.bounds.Min.x + ((geom.bounds.Max.x - geom.bounds.Min.x - textSize.x) / 2), geom.bounds.Min.y + ((geom.bounds.Max.y - geom.bounds.Min.y - textSize.y) / 2));
         m_drawList->AddText(textPos, kColorTextPrimary, clip->name.c_str());
     }
 

--- a/src/editor/panels/editor_panel_animation.h
+++ b/src/editor/panels/editor_panel_animation.h
@@ -150,7 +150,7 @@ private:
     RowDimensions AddRow(char const* label, RowOptions const& rowOptions);
     void DrawFrameNumberRibbon();
     void DrawClipRow(std::vector<AnimationIntent>& intents);
-    void DrawEventsRow();
+    void DrawEventsRow(std::vector<AnimationIntent>& intents);
     void DrawChildTrack(int childIndex, std::shared_ptr<moth_ui::Node> child);
     void DrawTrackRows();
     void DrawHorizScrollBar();

--- a/src/editor/panels/editor_panel_animation.h
+++ b/src/editor/panels/editor_panel_animation.h
@@ -39,6 +39,10 @@ struct DiscreteKeyframeContext {
     int mutableFrame = -1;
 };
 
+// Stored as int in m_clipDragHandle; Center is the bitwise OR of Left|Right so
+// resize math can test "left edge held?" / "right edge held?" independently.
+enum ClipDragHandle { kClipHandleNone = 0, kClipHandleLeft = 1, kClipHandleRight = 2, kClipHandleCenter = kClipHandleLeft | kClipHandleRight };
+
 class EditorPanelAnimation : public EditorPanel {
 public:
     EditorPanelAnimation(EditorLayer& editorLayer, bool visible);
@@ -172,8 +176,6 @@ private:
     float const m_labelColumnWidth = 200;               // width of the label column in pixels on the left side
     float const m_verticalScrollbarWidth = 18.0f;       // width of the vertical scrollbar area in pixels on the right side
     float const m_horizontalScrollbarHeight = 18.0f;    // height of the horizontal scrollbar area in pixels on the bottom side
-
-    enum ClipDragHandle { kClipHandleNone = 0, kClipHandleLeft = 1, kClipHandleRight = 2, kClipHandleCenter = kClipHandleLeft | kClipHandleRight };
 
     bool m_mouseDragging = false;           // currently dragging a clip/event/keyframe with the mouse
     float m_mouseDragStartX = 0.0f;         // pixel position of the mouse drag action start

--- a/src/editor/panels/editor_panel_animation.h
+++ b/src/editor/panels/editor_panel_animation.h
@@ -151,8 +151,8 @@ private:
     void DrawFrameNumberRibbon();
     void DrawClipRow(std::vector<AnimationIntent>& intents);
     void DrawEventsRow(std::vector<AnimationIntent>& intents);
-    void DrawChildTrack(int childIndex, std::shared_ptr<moth_ui::Node> child);
-    void DrawTrackRows();
+    void DrawChildTrack(int childIndex, std::shared_ptr<moth_ui::Node> child, std::vector<AnimationIntent>& intents);
+    void DrawTrackRows(std::vector<AnimationIntent>& intents);
     void DrawHorizScrollBar();
     void DrawCursor();
     int CalcNumRows() const;

--- a/src/editor/panels/editor_panel_animation.h
+++ b/src/editor/panels/editor_panel_animation.h
@@ -143,8 +143,8 @@ private:
     std::optional<EditContext<moth_ui::AnimationClip>> m_pendingClipEdit;
     std::optional<EditContext<moth_ui::AnimationMarker>> m_pendingEventEdit;
 
-    bool DrawClipPopup();
-    bool DrawEventPopup();
+    bool DrawClipPopup(std::vector<AnimationIntent>& intents);
+    bool DrawEventPopup(std::vector<AnimationIntent>& intents);
     bool DrawKeyframePopup();
 
     RowDimensions AddRow(char const* label, RowOptions const& rowOptions);

--- a/src/editor/panels/editor_panel_animation.h
+++ b/src/editor/panels/editor_panel_animation.h
@@ -145,7 +145,7 @@ private:
 
     bool DrawClipPopup(std::vector<AnimationIntent>& intents);
     bool DrawEventPopup(std::vector<AnimationIntent>& intents);
-    bool DrawKeyframePopup();
+    bool DrawKeyframePopup(std::vector<AnimationIntent>& intents);
 
     RowDimensions AddRow(char const* label, RowOptions const& rowOptions);
     void DrawFrameNumberRibbon();

--- a/src/editor/panels/editor_panel_animation.h
+++ b/src/editor/panels/editor_panel_animation.h
@@ -163,8 +163,9 @@ private:
     char const* GetChildLabel(int index) const;
     static char const* GetTrackLabel(moth_ui::AnimationTrack::Target target);
 
-    // Applies an intent emitted by a Draw function. Single place where clip
-    // click/drag/popup gestures mutate panel state.
+    // Applies an intent emitted by a Draw function. Single place where
+    // click/drag/popup/edit gestures mutate panel state — all selection
+    // changes, undo actions, and drag-state flags route through here.
     void Apply(AnimationIntent const& intent);
 
     int m_minFrame = 0;             // first visible frame
@@ -188,7 +189,7 @@ private:
     bool m_altDrag = false;                 // alt was held at any point during the current drag (for duplicate-on-drag)
     int m_clipDragHandle = kClipHandleNone; // section of the clip we're dragging
     int m_clickedFrame = -1;                // frame number clicked on, for popups etc
-    bool m_clickConsumed = false;           // false if we clicked and nothing responded to it
+    bool m_clickConsumed = false;           // set to true when a track element handled the current click
     bool m_grabbedCurrentFrame = false;     // dragging the current frame indicator
     bool m_mouseInScrollArea = false;       // true when the mouse is within the scrolling tracks area
 

--- a/src/editor/panels/editor_panel_animation.h
+++ b/src/editor/panels/editor_panel_animation.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "editor_panel.h"
+#include "animation_intent.h"
 #include "moth_ui/animation/animation_track.h"
 #include "moth_ui/animation/animation_clip.h"
 #include "moth_ui/animation/animation_marker.h"
@@ -9,6 +10,7 @@
 #include <memory>
 #include <optional>
 #include <variant>
+#include <vector>
 
 class IEditorAction;
 
@@ -147,7 +149,7 @@ private:
 
     RowDimensions AddRow(char const* label, RowOptions const& rowOptions);
     void DrawFrameNumberRibbon();
-    void DrawClipRow();
+    void DrawClipRow(std::vector<AnimationIntent>& intents);
     void DrawEventsRow();
     void DrawChildTrack(int childIndex, std::shared_ptr<moth_ui::Node> child);
     void DrawTrackRows();
@@ -160,6 +162,10 @@ private:
     void DrawWidget();
     char const* GetChildLabel(int index) const;
     static char const* GetTrackLabel(moth_ui::AnimationTrack::Target target);
+
+    // Applies an intent emitted by a Draw function. Single place where clip
+    // click/drag/popup gestures mutate panel state.
+    void Apply(AnimationIntent const& intent);
 
     int m_minFrame = 0;             // first visible frame
     int m_maxFrame = 100;           // last visible frame

--- a/src/editor/panels/editor_panel_asset_list.cpp
+++ b/src/editor/panels/editor_panel_asset_list.cpp
@@ -2,7 +2,7 @@
 #include "editor_panel_asset_list.h"
 #include "../editor_layer.h"
 #include "moth_ui/layout/layout.h"
-#include "moth_graphics/graphics/iimage.h"
+#include "moth_graphics/graphics/image.h"
 #include "moth_graphics/graphics/igraphics.h"
 #include "moth_graphics/graphics/surface_context.h"
 #include "moth_graphics/graphics/asset_context.h"
@@ -72,7 +72,7 @@ EditorPanelAssetList::EditorPanelAssetList(EditorLayer& editorLayer, bool visibl
         if (IsImageExtension(path.extension().string()) && ImGui::IsItemHovered()) {
             auto const key = path.string();
             if (m_imageCache.count(key) == 0) {
-                auto& factory = m_editorLayer.GetGraphics().GetSurfaceContext().GetAssetContext().GetTextureFactory();
+                auto& factory = m_editorLayer.GetAssetContext().GetTextureFactory();
                 auto texture = factory.GetTexture(path);
                 if (texture) {
                     m_imageCache[key] = moth_graphics::graphics::Image{ texture, factory.GetTextureRect(path) };

--- a/src/editor/panels/editor_panel_asset_list.cpp
+++ b/src/editor/panels/editor_panel_asset_list.cpp
@@ -6,7 +6,7 @@
 #include "moth_graphics/graphics/igraphics.h"
 #include "moth_graphics/graphics/surface_context.h"
 #include "moth_graphics/graphics/asset_context.h"
-#include "moth_graphics/graphics/image_factory.h"
+#include "moth_graphics/graphics/texture_factory.h"
 
 static std::string DragDropString;
 
@@ -72,17 +72,22 @@ EditorPanelAssetList::EditorPanelAssetList(EditorLayer& editorLayer, bool visibl
         if (IsImageExtension(path.extension().string()) && ImGui::IsItemHovered()) {
             auto const key = path.string();
             if (m_imageCache.count(key) == 0) {
-                auto& factory = m_editorLayer.GetGraphics().GetSurfaceContext().GetAssetContext().GetImageFactory();
-                m_imageCache[key] = factory.GetImage(path);
+                auto& factory = m_editorLayer.GetGraphics().GetSurfaceContext().GetAssetContext().GetTextureFactory();
+                auto texture = factory.GetTexture(path);
+                if (texture) {
+                    m_imageCache[key] = moth_graphics::graphics::Image{ texture, factory.GetTextureRect(path) };
+                } else {
+                    m_imageCache[key] = moth_graphics::graphics::Image{};
+                }
             }
-            auto const* image = m_imageCache.at(key).get();
-            if (image != nullptr) {
+            auto const& image = m_imageCache.at(key);
+            if (image) {
                 static constexpr int MaxTooltipDim = 256;
                 float const scale = std::min(
-                    static_cast<float>(MaxTooltipDim) / static_cast<float>(image->GetWidth()),
-                    static_cast<float>(MaxTooltipDim) / static_cast<float>(image->GetHeight()));
-                int const w = std::max(1, static_cast<int>(static_cast<float>(image->GetWidth()) * scale));
-                int const h = std::max(1, static_cast<int>(static_cast<float>(image->GetHeight()) * scale));
+                    static_cast<float>(MaxTooltipDim) / static_cast<float>(image.GetWidth()),
+                    static_cast<float>(MaxTooltipDim) / static_cast<float>(image.GetHeight()));
+                int const w = std::max(1, static_cast<int>(static_cast<float>(image.GetWidth()) * scale));
+                int const h = std::max(1, static_cast<int>(static_cast<float>(image.GetHeight()) * scale));
                 ImGui::BeginTooltip();
                 imgui_ext::Image(image, w, h);
                 ImGui::EndTooltip();

--- a/src/editor/panels/editor_panel_asset_list.h
+++ b/src/editor/panels/editor_panel_asset_list.h
@@ -10,7 +10,7 @@
 #include <memory>
 
 namespace moth_graphics::graphics {
-    class IImage;
+    class Image;
 }
 
 class EditorPanelAssetList : public EditorPanel {
@@ -24,7 +24,7 @@ public:
 private:
     ContentList m_contentList;
     std::filesystem::file_time_type m_lastDirWriteTime;
-    std::unordered_map<std::string, std::unique_ptr<moth_graphics::graphics::IImage>> m_imageCache;
+    std::unordered_map<std::string, moth_graphics::graphics::Image> m_imageCache;
 
     void DrawContents() override;
 };

--- a/src/editor/panels/editor_panel_canvas.cpp
+++ b/src/editor/panels/editor_panel_canvas.cpp
@@ -15,7 +15,6 @@
 #include "../actions/composite_action.h"
 #include "editor_application.h"
 #include "moth_ui/graphics/itarget.h"
-#include "moth_graphics/graphics/moth_ui/utils.h"
 #include "moth_ui/utils/transform.h"
 
 #include <cmath>

--- a/src/editor/panels/editor_panel_sprite_editor.cpp
+++ b/src/editor/panels/editor_panel_sprite_editor.cpp
@@ -15,7 +15,7 @@ EditorPanelSpriteEditor::EditorPanelSpriteEditor(EditorLayer& editorLayer, bool 
 }
 
 void EditorPanelSpriteEditor::LoadSpriteSheet(std::filesystem::path const& path) {
-    auto& assetContext = m_editorLayer.GetGraphics().GetSurfaceContext().GetAssetContext();
+    auto& assetContext = m_editorLayer.GetAssetContext();
     m_spriteSheet = assetContext.GetSpriteSheetFactory().GetSpriteSheet(path);
     if (!m_spriteSheet) {
         spdlog::error("Failed to load sprite sheet: {}", path.string());

--- a/src/editor/panels/editor_panel_sprite_editor.cpp
+++ b/src/editor/panels/editor_panel_sprite_editor.cpp
@@ -30,11 +30,11 @@ void EditorPanelSpriteEditor::DrawContents() {
     // ---- Left pane: sprite sheet preview ----
     ImGui::BeginChild("##sprite_preview", ImVec2(leftWidth, 0), ImGuiChildFlags_None, ImGuiWindowFlags_HorizontalScrollbar);
     if (m_spriteSheet) {
-        auto const* image = m_spriteSheet->GetImage().get();
-        if (image != nullptr) {
+        auto const& image = m_spriteSheet->GetImage();
+        if (image) {
             ImVec2 const avail = ImGui::GetContentRegionAvail();
-            float const imgW = static_cast<float>(image->GetWidth());
-            float const imgH = static_cast<float>(image->GetHeight());
+            float const imgW = static_cast<float>(image.GetWidth());
+            float const imgH = static_cast<float>(image.GetHeight());
 
             float displayW = avail.x;
             float displayH = (imgW > 0.0f) ? (displayW * imgH / imgW) : avail.y;
@@ -44,7 +44,7 @@ void EditorPanelSpriteEditor::DrawContents() {
             }
 
             ImVec2 const imagePos = ImGui::GetCursorScreenPos();
-            image->ImGui({ static_cast<int>(displayW), static_cast<int>(displayH) });
+            image.DrawImGui({ static_cast<int>(displayW), static_cast<int>(displayH) });
 
             // Overlay a yellow rect for each defined frame
             ImDrawList* const drawList = ImGui::GetWindowDrawList();
@@ -52,12 +52,11 @@ void EditorPanelSpriteEditor::DrawContents() {
             float const scaleY = (imgH > 0.0f) ? (displayH / imgH) : 1.0f;
 
             for (int i = 0; i < m_spriteSheet->GetFrameCount(); ++i) {
-                moth_graphics::graphics::SpriteSheet::FrameEntry frame;
-                if (m_spriteSheet->GetFrameDesc(i, frame)) {
-                    float const x0 = imagePos.x + (static_cast<float>(frame.rect.x()) * scaleX);
-                    float const y0 = imagePos.y + (static_cast<float>(frame.rect.y()) * scaleY);
-                    float const x1 = imagePos.x + (static_cast<float>(frame.rect.right()) * scaleX);
-                    float const y1 = imagePos.y + (static_cast<float>(frame.rect.bottom()) * scaleY);
+                if (auto frame = m_spriteSheet->GetFrameDesc(i)) {
+                    float const x0 = imagePos.x + (static_cast<float>(frame->rect.x()) * scaleX);
+                    float const y0 = imagePos.y + (static_cast<float>(frame->rect.y()) * scaleY);
+                    float const x1 = imagePos.x + (static_cast<float>(frame->rect.right()) * scaleX);
+                    float const y1 = imagePos.y + (static_cast<float>(frame->rect.bottom()) * scaleY);
                     drawList->AddRect({ x0, y0 }, { x1, y1 }, IM_COL32(255, 255, 0, 255));
                 }
             }
@@ -112,14 +111,13 @@ void EditorPanelSpriteEditor::DrawContents() {
                 ImGui::TableHeadersRow();
 
                 for (int i = 0; i < frameCount; ++i) {
-                    moth_graphics::graphics::SpriteSheet::FrameEntry frame;
-                    if (m_spriteSheet->GetFrameDesc(i, frame)) {
+                    if (auto frame = m_spriteSheet->GetFrameDesc(i)) {
                         ImGui::TableNextRow();
                         ImGui::TableSetColumnIndex(0); ImGui::Text("%d", i);
-                        ImGui::TableSetColumnIndex(1); ImGui::Text("%d", frame.rect.x());
-                        ImGui::TableSetColumnIndex(2); ImGui::Text("%d", frame.rect.y());
-                        ImGui::TableSetColumnIndex(3); ImGui::Text("%d", frame.rect.w());
-                        ImGui::TableSetColumnIndex(4); ImGui::Text("%d", frame.rect.h());
+                        ImGui::TableSetColumnIndex(1); ImGui::Text("%d", frame->rect.x());
+                        ImGui::TableSetColumnIndex(2); ImGui::Text("%d", frame->rect.y());
+                        ImGui::TableSetColumnIndex(3); ImGui::Text("%d", frame->rect.w());
+                        ImGui::TableSetColumnIndex(4); ImGui::Text("%d", frame->rect.h());
                     }
                 }
                 ImGui::EndTable();
@@ -134,23 +132,23 @@ void EditorPanelSpriteEditor::DrawContents() {
         if (ImGui::CollapsingHeader("Clips", ImGuiTreeNodeFlags_DefaultOpen)) {
             for (int c = 0; c < clipCount; ++c) {
                 auto const clipName = m_spriteSheet->GetClipName(c);
-                moth_graphics::graphics::SpriteSheet::ClipDesc clipDesc;
-                if (!m_spriteSheet->GetClipDesc(clipName, clipDesc)) {
+                auto clipDesc = m_spriteSheet->GetClipDesc(clipName);
+                if (!clipDesc) {
                     continue;
                 }
 
-                std::string const nodeLabel = fmt::format("{} ({} steps)###clip_{}", clipName, clipDesc.frames.size(), c);
+                std::string const nodeLabel = fmt::format("{} ({} steps)###clip_{}", clipName, clipDesc->frames.size(), c);
                 if (ImGui::TreeNode(nodeLabel.c_str())) {
                     char const* loopStr = nullptr;
-                    switch (clipDesc.loop) {
+                    switch (clipDesc->loop) {
                     case moth_graphics::graphics::SpriteSheet::LoopType::Stop:  loopStr = "stop";  break;
                     case moth_graphics::graphics::SpriteSheet::LoopType::Reset: loopStr = "reset"; break;
                     case moth_graphics::graphics::SpriteSheet::LoopType::Loop:  loopStr = "loop";  break;
                     }
                     ImGui::Text("Loop: %s", loopStr);
 
-                    if (!clipDesc.frames.empty()) {
-                        ImGui::Text("Frame duration: %d ms", clipDesc.frames[0].durationMs);
+                    if (!clipDesc->frames.empty()) {
+                        ImGui::Text("Frame duration: %d ms", clipDesc->frames[0].durationMs);
                     }
 
                     if (ImGui::BeginTable("##clip_steps", 2,
@@ -159,10 +157,10 @@ void EditorPanelSpriteEditor::DrawContents() {
                         ImGui::TableSetupColumn("Frame", ImGuiTableColumnFlags_WidthStretch);
                         ImGui::TableHeadersRow();
 
-                        for (int f = 0; f < static_cast<int>(clipDesc.frames.size()); ++f) {
+                        for (int f = 0; f < static_cast<int>(clipDesc->frames.size()); ++f) {
                             ImGui::TableNextRow();
                             ImGui::TableSetColumnIndex(0); ImGui::Text("%d", f);
-                            ImGui::TableSetColumnIndex(1); ImGui::Text("%d", clipDesc.frames[f].frameIndex);
+                            ImGui::TableSetColumnIndex(1); ImGui::Text("%d", clipDesc->frames[f].frameIndex);
                         }
                         ImGui::EndTable();
                     }

--- a/src/editor/sprite_editor/sprite_editor.cpp
+++ b/src/editor/sprite_editor/sprite_editor.cpp
@@ -77,7 +77,7 @@ void SpriteEditor::Draw() {
                     m_clipElapsedMs   = 0.0f;
                     m_zoom            = 1.0f;
                     m_spriteSheet     = std::make_shared<moth_graphics::graphics::SpriteSheet>(
-                        nullptr,
+                        moth_graphics::graphics::Image{},
                         std::vector<moth_graphics::graphics::SpriteSheet::FrameEntry>{},
                         std::vector<moth_graphics::graphics::SpriteSheet::ClipEntry>{});
                 }

--- a/src/editor/sprite_editor/sprite_editor_clips.cpp
+++ b/src/editor/sprite_editor/sprite_editor_clips.cpp
@@ -43,7 +43,7 @@ void SpriteEditor::DrawClipsPane() {
 
         // Draw the current frame, pivot-anchored
         auto const* image = (m_spriteSheet && m_spriteSheet->GetImage())
-                            ? m_spriteSheet->GetImage().get() : nullptr;
+                            ? &m_spriteSheet->GetImage() : nullptr;
         if (clip.desc.frames.empty()) {
             ImGui::TextDisabled("(no steps)");
         } else if (image != nullptr) {
@@ -113,7 +113,7 @@ void SpriteEditor::DrawClipsPane() {
                         ImGui::SetCursorScreenPos({
                             anchorX - (static_cast<float>(fr.pivot.x) * zoom),
                             anchorY - (static_cast<float>(fr.pivot.y) * zoom) });
-                        image->ImGui({ static_cast<int>(fw), static_cast<int>(fh) }, uv0, uv1);
+                        image->DrawImGui({ static_cast<int>(fw), static_cast<int>(fh) }, uv0, uv1);
                     }
                 }
 

--- a/src/editor/sprite_editor/sprite_editor_frames.cpp
+++ b/src/editor/sprite_editor/sprite_editor_frames.cpp
@@ -104,7 +104,7 @@ void SpriteEditor::DrawFramesPane() {
             // ---- Selected frame mini-preview (with pivot drag) ----
             ImGui::TableSetColumnIndex(1);
             auto const* image = (m_spriteSheet && m_spriteSheet->GetImage())
-                                ? m_spriteSheet->GetImage().get() : nullptr;
+                                ? &m_spriteSheet->GetImage() : nullptr;
             if (image != nullptr && m_selectedFrame >= 0 && m_selectedFrame < static_cast<int>(m_frames.size())) {
                 auto& fr = m_frames[m_selectedFrame];
                 float const imgW = static_cast<float>(image->GetWidth());
@@ -138,7 +138,7 @@ void SpriteEditor::DrawFramesPane() {
                         ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse)) {
                     ImVec2 const childMin = ImGui::GetWindowPos();
 
-                    image->ImGui({ static_cast<int>(dispW), static_cast<int>(dispH) }, uv0, uv1);
+                    image->DrawImGui({ static_cast<int>(dispW), static_cast<int>(dispH) }, uv0, uv1);
 
                     // InvisibleButton over the whole area so ImGui owns the left-button press
                     // and the parent window cannot start a drag.

--- a/src/editor/sprite_editor/sprite_editor_io.cpp
+++ b/src/editor/sprite_editor/sprite_editor_io.cpp
@@ -48,9 +48,9 @@ void SpriteEditor::LoadSpriteSheet(std::filesystem::path const& path) {
 
     m_frames.reserve(static_cast<size_t>(m_spriteSheet->GetFrameCount()));
     for (int i = 0; i < m_spriteSheet->GetFrameCount(); ++i) {
-        moth_graphics::graphics::SpriteSheet::FrameEntry entry;
-        m_spriteSheet->GetFrameDesc(i, entry);
-        m_frames.push_back(entry);
+        if (auto entry = m_spriteSheet->GetFrameDesc(i)) {
+            m_frames.push_back(*entry);
+        }
     }
 
     m_clips.clear();
@@ -59,18 +59,21 @@ void SpriteEditor::LoadSpriteSheet(std::filesystem::path const& path) {
     for (int i = 0; i < clipCount; ++i) {
         moth_graphics::graphics::SpriteSheet::ClipEntry entry;
         entry.name = m_spriteSheet->GetClipName(i);
-        m_spriteSheet->GetClipDesc(entry.name, entry.desc);
+        if (auto desc = m_spriteSheet->GetClipDesc(entry.name)) {
+            entry.desc = *desc;
+        }
         m_clips.push_back(std::move(entry));
     }
 }
 
 void SpriteEditor::ImportSheet(std::filesystem::path const& imagePath) {
     auto& assetContext = m_editorLayer.GetGraphics().GetSurfaceContext().GetAssetContext();
-    auto image = assetContext.ImageFromFile(imagePath);
-    if (!image) {
+    std::shared_ptr<moth_graphics::graphics::ITexture> texture(assetContext.TextureFromFile(imagePath));
+    if (!texture) {
         spdlog::error("SpriteEditor: failed to load image '{}'", imagePath.string());
         return;
     }
+    moth_graphics::graphics::Image image{ texture };
 
     ClearSpriteActions();
 
@@ -79,7 +82,7 @@ void SpriteEditor::ImportSheet(std::filesystem::path const& imagePath) {
     m_imagePathBuffer[sizeof(m_imagePathBuffer) - 1] = '\0';
 
     m_spriteSheet = std::make_shared<moth_graphics::graphics::SpriteSheet>(
-        std::shared_ptr<moth_graphics::graphics::IImage>(std::move(image)),
+        std::move(image),
         m_frames,
         m_clips);
     m_zoom = -1.0f;    // re-fit to new image dimensions

--- a/src/editor/sprite_editor/sprite_editor_io.cpp
+++ b/src/editor/sprite_editor/sprite_editor_io.cpp
@@ -10,7 +10,7 @@
 void SpriteEditor::LoadSpriteSheet(std::filesystem::path const& path) {
     // Load and validate before touching any editor state so a failed load
     // leaves the current document intact.
-    auto& assetContext = m_editorLayer.GetGraphics().GetSurfaceContext().GetAssetContext();
+    auto& assetContext = m_editorLayer.GetAssetContext();
     auto newSheet = assetContext.GetSpriteSheetFactory().GetSpriteSheet(path);
     if (!newSheet) {
         spdlog::error("Failed to load sprite sheet: {}", path.string());
@@ -67,7 +67,7 @@ void SpriteEditor::LoadSpriteSheet(std::filesystem::path const& path) {
 }
 
 void SpriteEditor::ImportSheet(std::filesystem::path const& imagePath) {
-    auto& assetContext = m_editorLayer.GetGraphics().GetSurfaceContext().GetAssetContext();
+    auto& assetContext = m_editorLayer.GetAssetContext();
     std::shared_ptr<moth_graphics::graphics::ITexture> texture(assetContext.TextureFromFile(imagePath));
     if (!texture) {
         spdlog::error("SpriteEditor: failed to load image '{}'", imagePath.string());
@@ -186,6 +186,6 @@ void SpriteEditor::SaveSpriteSheet() {
     }
 
     // Flush the factory cache so a subsequent load picks up the new data
-    auto& assetContext = m_editorLayer.GetGraphics().GetSurfaceContext().GetAssetContext();
+    auto& assetContext = m_editorLayer.GetAssetContext();
     assetContext.GetSpriteSheetFactory().FlushCache();
 }

--- a/src/editor/sprite_editor/sprite_editor_preview.cpp
+++ b/src/editor/sprite_editor/sprite_editor_preview.cpp
@@ -136,13 +136,13 @@ void SpriteEditor::DrawPreview() {
         return;
     }
 
-    auto const* image = m_spriteSheet->GetImage().get();
-    if (image == nullptr) {
+    auto const& image = m_spriteSheet->GetImage();
+    if (!image) {
         return;
     }
 
-    float const imgW = static_cast<float>(image->GetWidth());
-    float const imgH = static_cast<float>(image->GetHeight());
+    float const imgW = static_cast<float>(image.GetWidth());
+    float const imgH = static_cast<float>(image.GetHeight());
 
     // Auto-fit on first draw after a load
     ImVec2 const totalAvail = ImGui::GetContentRegionAvail();
@@ -199,7 +199,7 @@ void SpriteEditor::DrawPreview() {
     // Draw the atlas image, then overlay an InvisibleButton at the same position so
     // ImGui owns all left-button interactions (drag, cursor changes) on the canvas.
     ImVec2 const imagePos = ImGui::GetCursorScreenPos();
-    image->ImGui({ static_cast<int>(displayW), static_cast<int>(displayH) });
+    image.DrawImGui({ static_cast<int>(displayW), static_cast<int>(displayH) });
     ImGui::SetCursorScreenPos(imagePos);
     ImGui::InvisibleButton("##canvas_interact", ImVec2{ displayW, displayH });
 

--- a/src/editor/texture_packer/texture_packer.h
+++ b/src/editor/texture_packer/texture_packer.h
@@ -5,7 +5,6 @@
 
 #include <array>
 #include <filesystem>
-#include <memory>
 #include <vector>
 
 class EditorLayer;
@@ -37,7 +36,7 @@ private:
     // ---- Input state ----
     std::vector<moth_packer::ImageDetails> m_inputImages;
     int m_selectedInput = -1;
-    std::shared_ptr<moth_graphics::graphics::IImage> m_inputPreview;
+    moth_graphics::graphics::Image m_inputPreview;
     float m_inputZoom = 0.0f;  // 0 = fit-to-window; >0 = absolute scale
 
     // Pack options (persisted across pack/save)
@@ -64,7 +63,7 @@ private:
     // ---- Output state ----
     struct AtlasPreview {
         std::filesystem::path tempPath;
-        std::shared_ptr<moth_graphics::graphics::IImage> image;
+        moth_graphics::graphics::Image image;
         int width  = 0;
         int height = 0;
         std::vector<std::string>          imageNames;

--- a/src/editor/texture_packer/texture_packer.h
+++ b/src/editor/texture_packer/texture_packer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "moth_packer/packer.h"
-#include "moth_graphics/graphics/iimage.h"
+#include "moth_graphics/graphics/image.h"
 
 #include <array>
 #include <filesystem>

--- a/src/editor/texture_packer/texture_packer_input.cpp
+++ b/src/editor/texture_packer/texture_packer_input.cpp
@@ -35,8 +35,7 @@ void TexturePacker::DrawInputPanel() {
                     m_selectedInput = i;
                     m_inputZoom = 0.0f;
                     // Load preview image
-                    auto& assetContext = m_editorLayer.GetGraphics()
-                        .GetSurfaceContext().GetAssetContext();
+                    auto& assetContext = m_editorLayer.GetAssetContext();
                     {
                         std::shared_ptr<moth_graphics::graphics::ITexture> tex(assetContext.TextureFromFile(img.path));
                         m_inputPreview = tex ? moth_graphics::graphics::Image{ tex } : moth_graphics::graphics::Image{};

--- a/src/editor/texture_packer/texture_packer_input.cpp
+++ b/src/editor/texture_packer/texture_packer_input.cpp
@@ -37,7 +37,10 @@ void TexturePacker::DrawInputPanel() {
                     // Load preview image
                     auto& assetContext = m_editorLayer.GetGraphics()
                         .GetSurfaceContext().GetAssetContext();
-                    m_inputPreview = assetContext.ImageFromFile(img.path);
+                    {
+                        std::shared_ptr<moth_graphics::graphics::ITexture> tex(assetContext.TextureFromFile(img.path));
+                        m_inputPreview = tex ? moth_graphics::graphics::Image{ tex } : moth_graphics::graphics::Image{};
+                    }
                 }
             }
             ImGui::SameLine(ImGui::GetContentRegionAvail().x - 16.0f);
@@ -45,7 +48,7 @@ void TexturePacker::DrawInputPanel() {
                 m_inputImages.erase(m_inputImages.begin() + i);
                 if (m_selectedInput == i) {
                     m_selectedInput = -1;
-                    m_inputPreview.reset();
+                    m_inputPreview = moth_graphics::graphics::Image{};
                 } else if (m_selectedInput > i) {
                     --m_selectedInput;
                 }
@@ -75,8 +78,8 @@ void TexturePacker::DrawInputPanel() {
         if (ImGui::SmallButton("Fit##in")) { m_inputZoom = 0.0f; }
         ImGui::SameLine();
         if (ImGui::SmallButton("+##in")) {
-            float const srcW = static_cast<float>(m_inputPreview->GetWidth());
-            float const srcH = static_cast<float>(m_inputPreview->GetHeight());
+            float const srcW = static_cast<float>(m_inputPreview.GetWidth());
+            float const srcH = static_cast<float>(m_inputPreview.GetHeight());
             float const avW  = ImGui::GetContentRegionAvail().x;
             float const avH  = ImGui::GetContentRegionAvail().y * 0.30f;
             float fitScale = 1.0f;
@@ -88,8 +91,8 @@ void TexturePacker::DrawInputPanel() {
         }
         ImGui::SameLine();
         if (ImGui::SmallButton("-##in")) {
-            float const srcW = static_cast<float>(m_inputPreview->GetWidth());
-            float const srcH = static_cast<float>(m_inputPreview->GetHeight());
+            float const srcW = static_cast<float>(m_inputPreview.GetWidth());
+            float const srcH = static_cast<float>(m_inputPreview.GetHeight());
             float const avW  = ImGui::GetContentRegionAvail().x;
             float const avH  = ImGui::GetContentRegionAvail().y * 0.30f;
             float fitScale = 1.0f;
@@ -112,8 +115,8 @@ void TexturePacker::DrawInputPanel() {
 
             float const avW  = ImGui::GetContentRegionAvail().x;
             float const avH  = ImGui::GetContentRegionAvail().y;
-            float const srcW = static_cast<float>(m_inputPreview->GetWidth());
-            float const srcH = static_cast<float>(m_inputPreview->GetHeight());
+            float const srcW = static_cast<float>(m_inputPreview.GetWidth());
+            float const srcH = static_cast<float>(m_inputPreview.GetHeight());
             float fitScale = 1.0f;
             if (srcW > 0.0f && srcH > 0.0f) {
                 fitScale = std::min({ avW / srcW, avH / srcH, 1.0f });
@@ -130,7 +133,7 @@ void TexturePacker::DrawInputPanel() {
             }
 
             float const scale = (m_inputZoom <= 0.0f) ? fitScale : m_inputZoom;
-            m_inputPreview->ImGui({
+            m_inputPreview.DrawImGui({
                 static_cast<int>(srcW * scale),
                 static_cast<int>(srcH * scale) });
         } else {
@@ -180,7 +183,7 @@ void TexturePacker::DrawInputPanel() {
     if (ImGui::Button("Clear All") && !m_inputImages.empty()) {
         m_inputImages.clear();
         m_selectedInput = -1;
-        m_inputPreview.reset();
+        m_inputPreview = moth_graphics::graphics::Image{};
         m_hasPacked = false;
         m_previewAtlases.clear();
         m_selectedOutput = -1;

--- a/src/editor/texture_packer/texture_packer_output.cpp
+++ b/src/editor/texture_packer/texture_packer_output.cpp
@@ -74,7 +74,7 @@ void TexturePacker::DoPack() {
         return;
     }
 
-    auto& assetCtx = m_editorLayer.GetGraphics().GetSurfaceContext().GetAssetContext();
+    auto& assetCtx = m_editorLayer.GetAssetContext();
 
     if (m_flipbookMode) {
         // Flipbook descriptor: { "image": "preview.png", "frames": [...], "clips": [...] }

--- a/src/editor/texture_packer/texture_packer_output.cpp
+++ b/src/editor/texture_packer/texture_packer_output.cpp
@@ -82,10 +82,13 @@ void TexturePacker::DoPack() {
         if (!atlasFilename.empty()) {
             AtlasPreview preview;
             preview.tempPath = tmpDir / atlasFilename;
-            preview.image    = assetCtx.ImageFromFile(preview.tempPath);
+            {
+                std::shared_ptr<moth_graphics::graphics::ITexture> tex(assetCtx.TextureFromFile(preview.tempPath));
+                preview.image = tex ? moth_graphics::graphics::Image{ tex } : moth_graphics::graphics::Image{};
+            }
             if (preview.image) {
-                preview.width  = preview.image->GetWidth();
-                preview.height = preview.image->GetHeight();
+                preview.width  = preview.image.GetWidth();
+                preview.height = preview.image.GetHeight();
             }
             int frameIdx = 0;
             for (auto const& frameEntry : descriptor.value("frames", nlohmann::json::array())) {
@@ -107,10 +110,13 @@ void TexturePacker::DoPack() {
                 continue;
             }
             preview.tempPath = tmpDir / atlasFilename;
-            preview.image    = assetCtx.ImageFromFile(preview.tempPath);
+            {
+                std::shared_ptr<moth_graphics::graphics::ITexture> tex(assetCtx.TextureFromFile(preview.tempPath));
+                preview.image = tex ? moth_graphics::graphics::Image{ tex } : moth_graphics::graphics::Image{};
+            }
             if (preview.image) {
-                preview.width  = preview.image->GetWidth();
-                preview.height = preview.image->GetHeight();
+                preview.width  = preview.image.GetWidth();
+                preview.height = preview.image.GetHeight();
             }
 
             for (auto const& imgEntry : atlasEntry.value("images", nlohmann::json::array())) {
@@ -266,7 +272,7 @@ void TexturePacker::DrawOutputPanel() {
             }
 
             float const scale = (m_outputZoom <= 0.0f) ? fitScale : m_outputZoom;
-            atlas.image->ImGui({
+            atlas.image.DrawImGui({
                 static_cast<int>(srcW * scale),
                 static_cast<int>(srcH * scale) });
         } else {

--- a/src/editor_application.cpp
+++ b/src/editor_application.cpp
@@ -74,7 +74,7 @@ void EditorApplication::PostCreateWindow() {
         auto& assetContext = m_window->GetSurfaceContext().GetAssetContext();
         if (auto texture = assetContext.TextureFromPixels(kSize, kSize, pixels.data())) {
             texture->SetFilter(moth_graphics::graphics::TextureFilter::Nearest, moth_graphics::graphics::TextureFilter::Nearest);
-            m_window->GetImageFactory().SetFallbackImage(std::shared_ptr<moth_graphics::graphics::ITexture>(std::move(texture)));
+            m_window->GetTextureFactory().SetFallbackTexture(std::move(texture));
         }
     }
 

--- a/src/editor_application.cpp
+++ b/src/editor_application.cpp
@@ -88,5 +88,5 @@ void EditorApplication::PostCreateWindow() {
     }
 
     m_window->AddEventListener(this);
-    m_window->PushLayer(std::make_unique<EditorLayer>(m_window->GetMothContext(), m_window->GetGraphics(), this));
+    m_window->PushLayer(std::make_unique<EditorLayer>(m_window->GetMothContext(), m_window->GetGraphics(), m_window->GetSurfaceContext().GetAssetContext(), this));
 }


### PR DESCRIPTION
## Summary

Separates the animation panel's Draw functions from the state mutations they used to perform inline. Every click, popup activation, and drag-start gesture now emits an `AnimationIntent` value; a single `Apply` member function is the only place that mutates editor selection, calls `PerformEditAction`/`AddEditAction`, or sets click/drag/popup panel state. The goal is that purely visual changes to any Draw function can no longer accidentally invoke undo, change selection, or open popups — the compiler enforces it because emit-an-intent is the only mutation path available to Draw code.

Layered as seven small commits so each is reviewable and revertible:

1. `ebebb1d` Extract `ClipGeometry` + `HitTestClip` as pure free functions; move `ClipDragHandle` to file scope.
2. `5b5088d` Introduce `AnimationIntent` variant and `Apply` dispatcher; convert clip-row clicks/drag/popup-open.
3. `ae2e09b` Convert events row to the intent pattern.
4. `b4e3d8a` Route clip + event popup actions (Add/Delete/CommitEdit) through `Apply`.
5. `b928c10` Convert `DrawChildTrack`/`DrawTrackRows` — keyframe/discrete-keyframe selection, drag, label drag-to-reorder, popup-open.
6. `6ac6611` Convert `DrawKeyframePopup` — Add/Delete/Interp/discrete-value commits.
7. `d81c66a` Extract pure drag-math helpers (`ApplyClipDragSingle`, `ApplyClipDragMulti`, `SortDiscreteMovesForCommit`) from `UpdateMouseDragging`/`CommitDragActions`.

## Behavior notes

- Per-frame view state stays direct: `m_pendingClipEdit`/`m_pendingEventEdit`, `m_labelDragSourceIdx`/`m_labelDragging`, expand/collapse, `nameBuf`/`editBuf`, per-frame box-select staging, and intra-function gate locals (`dragIntentEmitted`, `handledRightClick`).
- One observable consequence: popup-emitted mutations now defer by one frame (drained after the row returns). MenuItem activations close the popup on the next frame anyway, so the user sees popup-close and new state together. Same applies to the Add/Delete/Commit paths in the keyframe popup.
- Overlapping clips on left-click: original mid-loop `m_mouseDragging=true` gate is replicated by a local `dragIntentEmitted` flag so the first-hit clip still wins (no behavior change).
- Right-click on empty space across collapsed discrete tracks: original emitted last-write-wins via shared `subTrackBounds`; preserved by emitting multiple `OpenKeyframePopup` intents whose Apply order produces the same result.

## Test plan

- [ ] Clip row: left-click select, ctrl-click multi-select, edge-resize drag (both edges + center body), right-click Add, right-click Delete, right-click Edit name/fps/loopType (commit on close, Esc cancels), box-select overlap, alt-drag ghost.
- [ ] Events row: same gestures (Add/Delete/Edit name) plus drag.
- [ ] Track rows: child label toggle/ctrl-toggle, child label drag-to-reorder, expand/collapse button, keyframe click in expanded and collapsed (sibling-keyframe filter) modes, discrete keyframe click.
- [ ] Keyframe popup: continuous Add on specific target, continuous Add on collapsed main row (composite over all continuous targets), Delete, Interp change across a multi-keyframe selection, discrete Add, discrete Playing checkbox + clipname combo (commit + popup close).
- [ ] Drag commit: clip move, clip resize-left, clip resize-right, multi-clip move with one going below frame 0, keyframe move, discrete keyframe move (multiple on same track moving same direction — sort prevents clobber), alt-drag duplicate for each type.
- [ ] Undo/redo each of the above produces the same single-step undo as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Timeline moved to an intent-driven flow for more predictable, consistent clip/event/keyframe interactions (clicks, drags, popups, commits).
  * Internal image handling unified to value-based images for more reliable preview rendering and caching across panels.

* **Improvements**
  * Sprite editor & texture packer: more robust asset loading, preview drawing, and frame/clip handling.
  * Editor initialization now wires asset context into the editor for improved asset management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/instinkt900/moth_editor/pull/26)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->