### PR TITLE
Gradient node editor support + font preview

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,11 +6,11 @@
 
 **Effort:** Small–Medium
 
-Animation events can be placed on the timeline and fire as named callbacks at runtime, but there
-is no way to attach a data payload in the editor. The `AnimationEvent` type in moth_ui needs to
-be checked for parameter support first — if it exists, the editor just needs a small addition to
-the event edit popup. If it doesn't, the type and serialisation need extending before the editor
-work can begin.
+Animation markers can be placed on the timeline and fire as named callbacks at runtime, but
+there is no way to attach a data payload in the editor. `moth_ui::AnimationMarker` currently
+stores only `frame` + `name` — the type and its serialisation need extending (e.g. a string→value
+map) before the editor work can begin. Once that exists, the event edit popup gains a small
+key/value list editor.
 
 ---
 
@@ -26,20 +26,15 @@ and evaluate keyframe easing.
 
 ---
 
-### Font Previews
+### Font Picker on Text Nodes
 
 **Effort:** Small–Medium
 
-Font names alone give no visual feedback. Two related improvements:
-
-1. **Fonts dialog preview.** The Fonts dialog (`Edit > Fonts`) should display a rendered sample of
-   the currently selected font (e.g. "AaBbCc 0123") below or beside the font list.
-
-2. **Font picker on text nodes.** The font dropdown in the properties panel for text nodes shows
-   only font names. Ideally each entry would render in its own typeface (requires custom
-   `ImGui::Selectable` drawing with per-item font push/pop, which is non-trivial). As an
-   alternative, a "Browse…" button could open a font picker popup that shows a rendered sample for
-   each registered font, letting the user pick visually rather than by name.
+The font dropdown in the properties panel for text nodes shows only font names. Ideally each
+entry would render in its own typeface (requires custom `ImGui::Selectable` drawing with per-item
+font push/pop, which is non-trivial). As an alternative, a "Browse…" button could open a font
+picker popup that shows a rendered sample for each registered font (same render-to-target
+approach used by the Fonts dialog preview), letting the user pick visually rather than by name.
 
 ---
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -21,7 +21,7 @@ class MothUIEditor(ConanFile):
     def requirements(self):
         self.requires("moth_ui/1.1.0")
         self.requires("moth_graphics/1.1.0")
-        self.requires("moth_packer/1.0.0-rc.1")
+        self.requires("moth_packer/1.0.0-rc.2")
 
     def system_requirements(self):
         if self.settings.os == "Linux":

--- a/conanfile.py
+++ b/conanfile.py
@@ -19,8 +19,8 @@ class MothUIEditor(ConanFile):
             self.version = load(self, "version.txt").strip()
 
     def requirements(self):
-        self.requires("moth_ui/1.0.0")
-        self.requires("moth_graphics/1.0.0")
+        self.requires("moth_ui/1.1.0")
+        self.requires("moth_graphics/1.1.0")
         self.requires("moth_packer/1.0.0-rc.1")
 
     def system_requirements(self):

--- a/src/editor/panels/editor_panel_animation.cpp
+++ b/src/editor/panels/editor_panel_animation.cpp
@@ -954,7 +954,13 @@ void EditorPanelAnimation::Apply(AnimationIntent const& intent) {
         } else {
             std::unique_ptr<CompositeAction> compositeAction = std::make_unique<CompositeAction>();
             for (auto&& target : AnimationTrack::ContinuousTargets) {
-                auto* trackPtr = childTracks.at(target).get();
+                auto trackIt = childTracks.find(target);
+                if (trackIt == childTracks.end()) {
+                    // Not all continuous targets exist on every entity (e.g. gradient
+                    // targets only live on LayoutEntityGradient).
+                    continue;
+                }
+                auto* trackPtr = trackIt->second.get();
                 if (nullptr == trackPtr->GetKeyframe(a->frame)) {
                     auto const currentValue = trackPtr->GetValueAtFrame(static_cast<float>(a->frame));
                     auto action = std::make_unique<AddKeyframeAction>(a->entity, target, a->frame, currentValue, moth_ui::InterpType::Linear);

--- a/src/editor/panels/editor_panel_elements.cpp
+++ b/src/editor/panels/editor_panel_elements.cpp
@@ -7,6 +7,7 @@
 #include "moth_ui/layout/layout_entity_clip.h"
 #include "moth_ui/layout/layout_entity_text.h"
 #include "moth_ui/layout/layout_entity_flipbook.h"
+#include "moth_ui/layout/layout_entity_gradient.h"
 #include "moth_ui/layout/layout.h"
 #include "moth_ui/nodes/group.h"
 #include "../element_utils.h"
@@ -73,6 +74,10 @@ namespace {
         {
             "Clip Rect",
             [](EditorLayer& editorLayer) { AddEntity<moth_ui::LayoutEntityClip>(editorLayer); },
+        },
+        {
+            "Gradient",
+            [](EditorLayer& editorLayer) { AddEntity<moth_ui::LayoutEntityGradient>(editorLayer); },
         },
         {
             "Flipbook",

--- a/src/editor/panels/editor_panel_fonts.cpp
+++ b/src/editor/panels/editor_panel_fonts.cpp
@@ -1,13 +1,26 @@
 #include "common.h"
 #include "editor_panel_fonts.h"
 #include "moth_ui/context.h"
+#include "moth_graphics/graphics/asset_context.h"
+#include "moth_graphics/graphics/font_factory.h"
+#include "moth_graphics/graphics/igraphics.h"
+#include "moth_graphics/graphics/itarget.h"
 #include "../editor_layer.h"
+#include "../imgui_ext.h"
 
 #include <nfd.h>
+
+namespace {
+    constexpr int kPreviewFontSize = 36;
+    constexpr float kPreviewHeight = 80.0f;
+    constexpr char const* kPreviewSampleText = "AaBbCc 0123";
+}
 
 EditorPanelFonts::EditorPanelFonts(EditorLayer& editorLayer)
     : m_editorLayer(editorLayer) {
 }
+
+EditorPanelFonts::~EditorPanelFonts() = default;
 
 void EditorPanelFonts::Draw() {
     if (!m_open) {
@@ -53,8 +66,10 @@ void EditorPanelFonts::Draw() {
     ImGui::Separator();
 
     // ── List + side buttons ──────────────────────────────────────────────────
-    // Reserve bottom area: path label + path text + separator + close button
-    float const bottomReserve = (ImGui::GetFrameHeightWithSpacing() * 3.0f) + ImGui::GetStyle().ItemSpacing.y;
+    // Reserve bottom area: separator + path + preview label + preview image + close
+    float const bottomReserve = (ImGui::GetFrameHeightWithSpacing() * 4.0f)
+                                + kPreviewHeight
+                                + (ImGui::GetStyle().ItemSpacing.y * 2.0f);
     float const listHeight = ImGui::GetContentRegionAvail().y - bottomReserve;
 
     float const sideButtonW = 110.0f;
@@ -102,13 +117,54 @@ void EditorPanelFonts::Draw() {
 
     // ── Path display ─────────────────────────────────────────────────────────
     ImGui::Separator();
-    if (m_selectedIndex >= 0 && m_selectedIndex < static_cast<int>(fontNames.size())) {
+    bool const hasSelection = m_selectedIndex >= 0 && m_selectedIndex < static_cast<int>(fontNames.size());
+    if (hasSelection) {
         std::string const path = fontFactory.GetFontPath(fontNames[m_selectedIndex]).string();
         ImGui::TextUnformatted("Path:");
         ImGui::SameLine();
         ImGui::TextWrapped("%s", path.c_str());
     } else {
         ImGui::TextDisabled("No font selected.");
+    }
+
+    // ── Preview ──────────────────────────────────────────────────────────────
+    ImGui::TextUnformatted("Preview:");
+    float const previewW = ImGui::GetContentRegionAvail().x;
+    moth_ui::IntVec2 const previewSize{
+        std::max(1, static_cast<int>(previewW)),
+        static_cast<int>(kPreviewHeight),
+    };
+
+    auto& graphics = m_editorLayer.GetGraphics();
+    if (!m_previewTarget || m_previewTargetSize != previewSize) {
+        m_previewTarget = graphics.CreateTarget(previewSize.x, previewSize.y);
+        m_previewTargetSize = previewSize;
+    }
+
+    if (m_previewTarget) {
+        graphics.SetTarget(m_previewTarget.get());
+        graphics.SetBlendMode(moth_ui::BlendMode::Replace);
+        graphics.SetColor(moth_ui::Color{ 0.12f, 0.12f, 0.12f, 1.0f });
+        graphics.Clear();
+
+        if (hasSelection) {
+            auto const fontPath = fontFactory.GetFontPath(fontNames[m_selectedIndex]);
+            auto previewFont = m_editorLayer.GetAssetContext().GetFontFactory().GetFont(fontPath.string(), kPreviewFontSize);
+            if (previewFont) {
+                graphics.SetBlendMode(moth_ui::BlendMode::Alpha);
+                graphics.SetColor(moth_ui::Color{ 1.0f, 1.0f, 1.0f, 1.0f });
+                moth_ui::IntRect textRect;
+                textRect.topLeft = { 8, 0 };
+                textRect.bottomRight = { previewSize.x - 8, previewSize.y };
+                graphics.DrawText(kPreviewSampleText, *previewFont, textRect,
+                                  moth_ui::TextHorizAlignment::Left,
+                                  moth_ui::TextVertAlignment::Middle);
+            }
+        }
+
+        graphics.SetTarget(nullptr);
+
+        imgui_ext::Image(m_previewTarget->GetImage(), previewSize.x, previewSize.y);
     }
 
     // ── Close button (bottom-right) ───────────────────────────────────────────

--- a/src/editor/panels/editor_panel_fonts.cpp
+++ b/src/editor/panels/editor_panel_fonts.cpp
@@ -153,9 +153,7 @@ void EditorPanelFonts::Draw() {
             if (previewFont) {
                 graphics.SetBlendMode(moth_ui::BlendMode::Alpha);
                 graphics.SetColor(moth_ui::Color{ 1.0f, 1.0f, 1.0f, 1.0f });
-                moth_ui::IntRect textRect;
-                textRect.topLeft = { 8, 0 };
-                textRect.bottomRight = { previewSize.x - 8, previewSize.y };
+                moth_ui::IntRect const textRect{ { 8, 0 }, { previewSize.x - 8, previewSize.y } };
                 graphics.DrawText(kPreviewSampleText, *previewFont, textRect,
                                   moth_ui::TextHorizAlignment::Left,
                                   moth_ui::TextVertAlignment::Middle);

--- a/src/editor/panels/editor_panel_fonts.h
+++ b/src/editor/panels/editor_panel_fonts.h
@@ -1,13 +1,20 @@
 #pragma once
 
+#include "moth_ui/utils/vector.h"
+
 #include <filesystem>
+#include <memory>
+
+namespace moth_graphics::graphics {
+    class ITarget;
+}
 
 class EditorLayer;
 
 class EditorPanelFonts {
 public:
     explicit EditorPanelFonts(EditorLayer& editorLayer);
-    ~EditorPanelFonts() = default;
+    ~EditorPanelFonts();
 
     void Open() { m_open = true; }
     void Draw();
@@ -18,4 +25,7 @@ private:
 
     int m_selectedIndex = -1;
     std::filesystem::path m_pendingFontPath;
+
+    std::unique_ptr<moth_graphics::graphics::ITarget> m_previewTarget;
+    moth_ui::IntVec2 m_previewTargetSize{ 0, 0 };
 };

--- a/src/editor/panels/editor_panel_properties.cpp
+++ b/src/editor/panels/editor_panel_properties.cpp
@@ -18,6 +18,7 @@
 #include "../actions/modify_keyframe_action.h"
 #include "../actions/composite_action.h"
 #include "moth_ui/animation/animation_track.h"
+#include "moth_ui/utils/transform.h"
 #include "moth_ui/animation/keyframe.h"
 #include "moth_ui/layout/layout.h"
 #include "moth_ui/nodes/node_rect.h"
@@ -752,17 +753,16 @@ void EditorPanelProperties::DrawGradientProperties(std::shared_ptr<moth_ui::Node
     // Storage is in radians; the editor exposes degrees to match the
     // convention used by node rotation. Convert on display and on commit.
     PropertiesInput<float>(
-        "Angle (deg)", current.angle * (180.0f / 3.14159265358979323846f),
+        "Angle (deg)", current.angle * moth_ui::kRadToDeg,
         [node](float changedValueDeg) {
             auto g = node->GetGradient();
-            g.angle = changedValueDeg * (3.14159265358979323846f / 180.0f);
+            g.angle = changedValueDeg * moth_ui::kDegToRad;
             node->SetGradient(g);
         },
         [commitScalar](float oldValueDeg, float newValueDeg) {
-            constexpr float kDegToRad = 3.14159265358979323846f / 180.0f;
             commitScalar(moth_ui::AnimationTarget::GradientAngle,
-                         oldValueDeg * kDegToRad,
-                         newValueDeg * kDegToRad);
+                         oldValueDeg * moth_ui::kDegToRad,
+                         newValueDeg * moth_ui::kDegToRad);
         });
 
     PropertiesInput<float>(

--- a/src/editor/panels/editor_panel_properties.cpp
+++ b/src/editor/panels/editor_panel_properties.cpp
@@ -12,12 +12,19 @@
 #include "moth_ui/layout/layout_entity_text.h"
 #include "moth_ui/layout/layout_entity_ref.h"
 #include "moth_ui/layout/layout_entity_flipbook.h"
+#include "moth_ui/layout/layout_entity_gradient.h"
 #include "../actions/add_discrete_keyframe_action.h"
+#include "../actions/add_keyframe_action.h"
+#include "../actions/modify_keyframe_action.h"
+#include "../actions/composite_action.h"
+#include "moth_ui/animation/animation_track.h"
+#include "moth_ui/animation/keyframe.h"
 #include "moth_ui/layout/layout.h"
 #include "moth_ui/nodes/node_rect.h"
 #include "moth_ui/nodes/node_image.h"
 #include "moth_ui/nodes/node_text.h"
 #include "moth_ui/nodes/node_flipbook.h"
+#include "moth_ui/nodes/node_gradient.h"
 #include "moth_ui/nodes/group.h"
 #include "moth_ui/context.h"
 
@@ -86,6 +93,9 @@ void EditorPanelProperties::DrawNodeProperties(std::shared_ptr<moth_ui::Node> no
         break;
     case moth_ui::LayoutEntityType::Flipbook:
         DrawFlipbookProperties(std::static_pointer_cast<moth_ui::NodeFlipbook>(node));
+        break;
+    case moth_ui::LayoutEntityType::Gradient:
+        DrawGradientProperties(std::static_pointer_cast<moth_ui::NodeGradient>(node));
         break;
     case moth_ui::LayoutEntityType::Ref:
         DrawRefProperties(std::static_pointer_cast<moth_ui::Group>(node), recurseChildren);
@@ -635,6 +645,138 @@ void EditorPanelProperties::DrawFlipbookProperties(std::shared_ptr<moth_ui::Node
     }
 }
 
+void EditorPanelProperties::DrawGradientProperties(std::shared_ptr<moth_ui::NodeGradient> node) {
+    auto const entity = std::static_pointer_cast<moth_ui::LayoutEntityGradient>(node->GetLayoutEntity());
+
+    ImGui::SeparatorText("Gradient");
+
+    int const frameNo = m_editorLayer.GetSelectedFrame();
+    auto const current = entity->GetGradientAtFrame(static_cast<float>(frameNo));
+
+    // Push a keyframe at the current selected frame for one of the gradient's
+    // scalar tracks; if a keyframe already exists at the frame, modify it.
+    auto setTrackKeyframe = [entity, frameNo](moth_ui::AnimationTrack::Target target, float newValue) -> std::unique_ptr<IEditorAction> {
+        auto& track = entity->m_tracks.at(target);
+        if (auto* kf = track->GetKeyframe(frameNo)) {
+            if (kf->value == newValue) {
+                return nullptr;
+            }
+            return std::make_unique<ModifyKeyframeAction>(entity, target, frameNo, kf->value, newValue, kf->interpType, kf->interpType);
+        }
+        return std::make_unique<AddKeyframeAction>(entity, target, frameNo, newValue, moth_ui::InterpType::Linear);
+    };
+
+    auto commitColor = [this, node, setTrackKeyframe](moth_ui::Color const& oldColor, moth_ui::Color const& newColor,
+                                                       moth_ui::AnimationTarget rTarget, moth_ui::AnimationTarget gTarget,
+                                                       moth_ui::AnimationTarget bTarget, moth_ui::AnimationTarget aTarget) {
+        auto composite = std::make_unique<CompositeAction>();
+        auto add = [&](moth_ui::AnimationTarget t, float oldV, float newV) {
+            if (oldV == newV) { return; }
+            if (auto action = setTrackKeyframe(t, newV)) {
+                composite->GetActions().push_back(std::move(action));
+            }
+        };
+        add(rTarget, oldColor.r, newColor.r);
+        add(gTarget, oldColor.g, newColor.g);
+        add(bTarget, oldColor.b, newColor.b);
+        add(aTarget, oldColor.a, newColor.a);
+        if (!composite->GetActions().empty()) {
+            m_editorLayer.PerformEditAction(std::move(composite));
+            node->ReloadEntity();
+        }
+    };
+
+    auto commitScalar = [this, node, setTrackKeyframe](moth_ui::AnimationTarget target, float oldValue, float newValue) {
+        if (oldValue == newValue) { return; }
+        if (auto action = setTrackKeyframe(target, newValue)) {
+            m_editorLayer.PerformEditAction(std::move(action));
+            node->ReloadEntity();
+        }
+    };
+
+    PropertiesInput<moth_ui::Color>(
+        "Start Color", current.startColor,
+        [node](moth_ui::Color changedValue) {
+            auto g = node->GetGradient();
+            g.startColor = changedValue;
+            node->SetGradient(g);
+        },
+        [commitColor](moth_ui::Color oldValue, moth_ui::Color newValue) {
+            commitColor(oldValue, newValue,
+                        moth_ui::AnimationTarget::GradientStartRed,
+                        moth_ui::AnimationTarget::GradientStartGreen,
+                        moth_ui::AnimationTarget::GradientStartBlue,
+                        moth_ui::AnimationTarget::GradientStartAlpha);
+        });
+
+    PropertiesInput<moth_ui::Color>(
+        "End Color", current.endColor,
+        [node](moth_ui::Color changedValue) {
+            auto g = node->GetGradient();
+            g.endColor = changedValue;
+            node->SetGradient(g);
+        },
+        [commitColor](moth_ui::Color oldValue, moth_ui::Color newValue) {
+            commitColor(oldValue, newValue,
+                        moth_ui::AnimationTarget::GradientEndRed,
+                        moth_ui::AnimationTarget::GradientEndGreen,
+                        moth_ui::AnimationTarget::GradientEndBlue,
+                        moth_ui::AnimationTarget::GradientEndAlpha);
+        });
+
+    PropertiesInput<moth_ui::FloatVec2>(
+        "Midpoint", current.midpoint,
+        [node](moth_ui::FloatVec2 changedValue) {
+            auto g = node->GetGradient();
+            g.midpoint = changedValue;
+            node->SetGradient(g);
+        },
+        [this, node, setTrackKeyframe](moth_ui::FloatVec2 oldValue, moth_ui::FloatVec2 newValue) {
+            auto composite = std::make_unique<CompositeAction>();
+            if (oldValue.x != newValue.x) {
+                if (auto action = setTrackKeyframe(moth_ui::AnimationTarget::GradientMidpointX, newValue.x)) {
+                    composite->GetActions().push_back(std::move(action));
+                }
+            }
+            if (oldValue.y != newValue.y) {
+                if (auto action = setTrackKeyframe(moth_ui::AnimationTarget::GradientMidpointY, newValue.y)) {
+                    composite->GetActions().push_back(std::move(action));
+                }
+            }
+            if (!composite->GetActions().empty()) {
+                m_editorLayer.PerformEditAction(std::move(composite));
+                node->ReloadEntity();
+            }
+        });
+
+    // Storage is in radians; the editor exposes degrees to match the
+    // convention used by node rotation. Convert on display and on commit.
+    PropertiesInput<float>(
+        "Angle (deg)", current.angle * (180.0f / 3.14159265358979323846f),
+        [node](float changedValueDeg) {
+            auto g = node->GetGradient();
+            g.angle = changedValueDeg * (3.14159265358979323846f / 180.0f);
+            node->SetGradient(g);
+        },
+        [commitScalar](float oldValueDeg, float newValueDeg) {
+            constexpr float kDegToRad = 3.14159265358979323846f / 180.0f;
+            commitScalar(moth_ui::AnimationTarget::GradientAngle,
+                         oldValueDeg * kDegToRad,
+                         newValueDeg * kDegToRad);
+        });
+
+    PropertiesInput<float>(
+        "Transition", current.transitionLength,
+        [node](float changedValue) {
+            auto g = node->GetGradient();
+            g.transitionLength = changedValue;
+            node->SetGradient(g);
+        },
+        [commitScalar](float oldValue, float newValue) {
+            commitScalar(moth_ui::AnimationTarget::GradientTransition, oldValue, newValue);
+        });
+}
+
 char const* GetChildName(std::shared_ptr<moth_ui::LayoutEntity> entity) {
     switch (entity->GetType()) {
     case moth_ui::LayoutEntityType::Entity:
@@ -650,6 +792,8 @@ char const* GetChildName(std::shared_ptr<moth_ui::LayoutEntity> entity) {
         return "Text";
     case moth_ui::LayoutEntityType::Flipbook:
         return "Flipbook";
+    case moth_ui::LayoutEntityType::Gradient:
+        return "Gradient";
     case moth_ui::LayoutEntityType::Ref:
         return "Ref";
     default:

--- a/src/editor/panels/editor_panel_properties.h
+++ b/src/editor/panels/editor_panel_properties.h
@@ -27,6 +27,7 @@ private:
     void DrawImageProperties(std::shared_ptr<moth_ui::NodeImage> node);
     void DrawTextProperties(std::shared_ptr<moth_ui::NodeText> node);
     void DrawFlipbookProperties(std::shared_ptr<moth_ui::NodeFlipbook> node);
+    void DrawGradientProperties(std::shared_ptr<moth_ui::NodeGradient> node);
     void DrawRefProperties(std::shared_ptr<moth_ui::Group> node, bool recurseChildren);
     void DrawLayoutProperties(std::shared_ptr<moth_ui::Group> node);
 };


### PR DESCRIPTION
## Summary

Editor support for the moth_ui gradient node, plus a font preview in the Fonts
dialog. Bumps the moth_ui/moth_graphics dependencies to 1.1.0, which the
gradient work requires.

### Gradient node support
- Add a **Gradient** entry to the element-creation menu.
- New properties panel for gradient nodes (`DrawGradientProperties`): start/end
  colour editing wired to keyframes via the gradient animation targets.
- Fix a crash in the animation panel: continuous-target tracks don't exist on
  every entity (gradient targets live only on gradient nodes), so look them up
  with `find()` and skip missing ones instead of `at()`.

### Font preview
- The Fonts dialog (`Edit > Fonts`) renders a sample of the selected font.

### Dependencies
- Bump `moth_ui` 1.0.0 → 1.1.0 (NodeGradient, LayoutEntityGradient, gradient
  animation targets) and `moth_graphics` 1.0.0 → 1.1.0. moth_ui 1.1.0 makes
  `IRenderer::RenderGradientRect` pure virtual, so moth_graphics 1.1.0 (which
  implements it) is required for `MothRenderer` to compile.

### Docs
- Refresh the editor TODO: drop the completed fonts-dialog preview item and
  correct the animation-event payload note to reference `AnimationMarker`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gradient UI element support—users can now create and customize gradient elements in the editor.
  * Font picker now displays live preview samples, enabling visual font selection instead of name-based selection.
  * Gradient properties panel allows editing gradient parameters and keyframes.

* **Bug Fixes**
  * Fixed crash when adding animation keyframes for non-existent continuous animation tracks.

* **Chores**
  * Updated dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->